### PR TITLE
Make tests use their specific package

### DIFF
--- a/org.eclipse.tm4e.core.tests/src/test/java/org/eclipse/tm4e/core/grammar/test/MatcherTestImpl.java
+++ b/org.eclipse.tm4e.core.tests/src/test/java/org/eclipse/tm4e/core/grammar/test/MatcherTestImpl.java
@@ -8,7 +8,7 @@
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
  */
-package org.eclipse.tm4e.core.grammar;
+package org.eclipse.tm4e.core.grammar.test;
 
 import java.util.Collection;
 import java.util.List;

--- a/org.eclipse.tm4e.core.tests/src/test/java/org/eclipse/tm4e/core/grammar/test/RawTestImpl.java
+++ b/org.eclipse.tm4e.core.tests/src/test/java/org/eclipse/tm4e/core/grammar/test/RawTestImpl.java
@@ -8,7 +8,7 @@
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
  */
-package org.eclipse.tm4e.core.grammar;
+package org.eclipse.tm4e.core.grammar.test;
 
 import java.io.File;
 import java.io.IOException;
@@ -18,6 +18,10 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.eclipse.tm4e.core.grammar.IGrammar;
+import org.eclipse.tm4e.core.grammar.IToken;
+import org.eclipse.tm4e.core.grammar.ITokenizeLineResult;
+import org.eclipse.tm4e.core.grammar.StackElement;
 import org.eclipse.tm4e.core.registry.IGrammarLocator;
 import org.eclipse.tm4e.core.registry.Registry;
 import org.junit.Assert;

--- a/org.eclipse.tm4e.core.tests/src/test/java/org/eclipse/tm4e/core/grammar/test/RawTestLine.java
+++ b/org.eclipse.tm4e.core.tests/src/test/java/org/eclipse/tm4e/core/grammar/test/RawTestLine.java
@@ -8,7 +8,7 @@
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
  */
-package org.eclipse.tm4e.core.grammar;
+package org.eclipse.tm4e.core.grammar.test;
 
 import java.util.List;
 

--- a/org.eclipse.tm4e.core.tests/src/test/java/org/eclipse/tm4e/core/grammar/test/RawToken.java
+++ b/org.eclipse.tm4e.core.tests/src/test/java/org/eclipse/tm4e/core/grammar/test/RawToken.java
@@ -8,7 +8,7 @@
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
  */
-package org.eclipse.tm4e.core.grammar;
+package org.eclipse.tm4e.core.grammar.test;
 
 import java.util.List;
 

--- a/org.eclipse.tm4e.core.tests/src/test/java/org/eclipse/tm4e/core/grammar/test/VSCodeTextMateTest.java
+++ b/org.eclipse.tm4e.core.tests/src/test/java/org/eclipse/tm4e/core/grammar/test/VSCodeTextMateTest.java
@@ -8,7 +8,7 @@
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
  */
-package org.eclipse.tm4e.core.grammar;
+package org.eclipse.tm4e.core.grammar.test;
 
 import java.io.File;
 import java.io.FileReader;

--- a/org.eclipse.tm4e.core/.classpath
+++ b/org.eclipse.tm4e.core/.classpath
@@ -6,8 +6,6 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry exported="true" kind="lib" path="lib/jcodings-1.0.13.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/joni-2.1.11.jar"/>
 	<classpathentry kind="src" path="src/main/java"/>
 	<classpathentry kind="src" path="src/test/java"/>
 	<classpathentry kind="src" path="src/test/resources"/>


### PR DESCRIPTION
To avoid issue regarding signature, if we want to keep using plain
`maven-surefire-plugin` instead of `tycho-surefire-plugin` for the core
parts, we need tests to be in their own package.

Signed-off-by: Mickael Istria <mistria@redhat.com>