### PR TITLE
Minor change in consumer names

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Here a sample with TypeScript:
 
 Here are some projects that use tm4e:
 
- * [Eclipse BlueSky](https://github.com/mickaelistria/eclipse-bluesky) a simple and productive Web Development Tools in the Eclipse IDE.
- * [aCute](https://github.com/eclipse/aCute) C# edition in Eclipse IDE.
+ * [BlueSky for Eclipse IDE](https://github.com/mickaelistria/eclipse-bluesky) a simple and productive Web Development Tools in the Eclipse IDE.
+ * [Eclipse aCute](https://github.com/eclipse/aCute) C# edition in Eclipse IDE.
  * [typescript.java](https://github.com/angelozerr/typescript.java) TypeScript IDE for Eclipse with JSDT & tsserver.
  
 ## Get support and contribute


### PR DESCRIPTION
According to Eclipse.org trademark `Eclipse XXX` is reserved for Eclipse.org projects only. BlueSky isn't (yet) an Eclipse.org project, whereas aCute is.