### PR TITLE
Issue #141 Matching bracket support with language configuration

### DIFF
--- a/org.eclipse.tm4e.languageconfiguration/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.languageconfiguration/META-INF/MANIFEST.MF
@@ -17,6 +17,8 @@ Require-Bundle: org.eclipse.jface.text,
  org.eclipse.ui.ide,
  org.eclipse.core.filebuffers,
  org.eclipse.core.filesystem,
- org.eclipse.tm4e.registry
+ org.eclipse.tm4e.registry,
+ org.eclipse.ui.editors,
+ org.eclipse.e4.ui.css.swt.theme
 Bundle-Activator: org.eclipse.tm4e.languageconfiguration.internal.LanguageConfigurationPlugin
 Export-Package: org.eclipse.tm4e.languageconfiguration

--- a/org.eclipse.tm4e.languageconfiguration/build.properties
+++ b/org.eclipse.tm4e.languageconfiguration/build.properties
@@ -4,4 +4,5 @@ bin.includes = META-INF/,\
                .,\
                schema/,\
                plugin.xml,\
-               plugin.properties
+               plugin.properties,\
+               resources/

--- a/org.eclipse.tm4e.languageconfiguration/plugin.xml
+++ b/org.eclipse.tm4e.languageconfiguration/plugin.xml
@@ -37,5 +37,45 @@
           contentType="org.eclipse.core.runtime.text">
       </autoEditStrategy>
   </extension>
-	
+  <extension
+        point="org.eclipse.ui.genericeditor.highlightReconcilers">
+     <highlightReconciler
+           class="org.eclipse.tm4e.languageconfiguration.LanguageConfigurationBracketMatchingReconciler"
+           contentType="org.eclipse.core.runtime.text">
+     </highlightReconciler>
+  </extension>
+  <extension
+        point="org.eclipse.ui.editors.annotationTypes">
+     <type
+           name="org.eclipse.tm4e.languageconfiguration.bracketmatching">
+     </type>
+  </extension>
+  <extension
+        point="org.eclipse.ui.editors.markerAnnotationSpecification">
+     <specification
+           annotationType="org.eclipse.tm4e.languageconfiguration.bracketmatching"
+           label="Matching Pair"
+			textPreferenceKey="TM4EMatchingPair" textPreferenceValue="false"
+			highlightPreferenceKey="TM4EMatchingPairHighlighting"
+			highlightPreferenceValue="true" contributesToHeader="false"
+			overviewRulerPreferenceKey="TM4EMatchingPairInOverviewRuler"
+			overviewRulerPreferenceValue="true"
+			verticalRulerPreferenceKey="TM4EMatchingPairInVerticalRuler"
+			verticalRulerPreferenceValue="false" colorPreferenceKey="TM4EMatchingPairColor"
+			colorPreferenceValue="212,212,212" presentationLayer="4"
+			showInNextPrevDropdownToolbarAction="true"
+			textStylePreferenceKey="TM4EMatchingPairTextStyle"
+			textStylePreferenceValue="NONE"
+           includeOnPreferencePage="true">
+     </specification>
+  </extension>
+  <extension
+        point="org.eclipse.e4.ui.css.swt.theme">
+     <stylesheet
+           uri="resources/css/dark.css">
+        <themeid
+              refid="org.eclipse.e4.ui.css.theme.e4_dark">
+        </themeid>
+     </stylesheet>
+  </extension>
 </plugin>

--- a/org.eclipse.tm4e.languageconfiguration/resources/css/dark.css
+++ b/org.eclipse.tm4e.languageconfiguration/resources/css/dark.css
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Red Hat Inc. and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Lucas Bullen (Red Hat Inc.) - initial implementation
+ *******************************************************************************/
+IEclipsePreferences#org-eclipse-ui-editors:org-eclipse-tm4e-languageconfiguration {
+  preferences: 
+        'TM4EMatchingPairColor=27,98,145'
+}

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/LanguageConfigurationBracketMatchingReconciler.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/LanguageConfigurationBracketMatchingReconciler.java
@@ -1,0 +1,35 @@
+/**
+ *  Copyright (c) 2018 Red Hat Inc. and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Lucas Bullen (Red Hat Inc.) - initial API and implementation
+ */
+package org.eclipse.tm4e.languageconfiguration;
+
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.reconciler.MonoReconciler;
+
+public class LanguageConfigurationBracketMatchingReconciler extends MonoReconciler {
+	public LanguageConfigurationBracketMatchingReconciler() {
+		super(new LanguageConfigurationBracketMatchingReconcilingStrategy(), false);
+	}
+
+	@Override
+	public void install(ITextViewer textViewer) {
+		super.install(textViewer);
+		((LanguageConfigurationBracketMatchingReconcilingStrategy) getReconcilingStrategy(
+				IDocument.DEFAULT_CONTENT_TYPE)).install(textViewer);
+	}
+
+	@Override
+	public void uninstall() {
+		super.uninstall();
+		((LanguageConfigurationBracketMatchingReconcilingStrategy) getReconcilingStrategy(
+				IDocument.DEFAULT_CONTENT_TYPE)).uninstall();
+	}
+}

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/LanguageConfigurationBracketMatchingReconcilingStrategy.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/LanguageConfigurationBracketMatchingReconcilingStrategy.java
@@ -1,0 +1,353 @@
+/**
+ *  Copyright (c) 2018 Red Hat Inc. and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Lucas Bullen (Red Hat Inc.) - initial API and implementation
+ */
+package org.eclipse.tm4e.languageconfiguration;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.content.IContentType;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences.IPreferenceChangeListener;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences.PreferenceChangeEvent;
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.ITextSelection;
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.Position;
+import org.eclipse.jface.text.reconciler.DirtyRegion;
+import org.eclipse.jface.text.reconciler.IReconcilingStrategy;
+import org.eclipse.jface.text.reconciler.IReconcilingStrategyExtension;
+import org.eclipse.jface.text.source.Annotation;
+import org.eclipse.jface.text.source.IAnnotationModel;
+import org.eclipse.jface.text.source.ISourceViewer;
+import org.eclipse.jface.viewers.IPostSelectionProvider;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.ISelectionChangedListener;
+import org.eclipse.jface.viewers.ISelectionProvider;
+import org.eclipse.jface.viewers.SelectionChangedEvent;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.tm4e.languageconfiguration.internal.LanguageConfigurationPlugin;
+import org.eclipse.tm4e.languageconfiguration.internal.LanguageConfigurationRegistryManager;
+import org.eclipse.tm4e.languageconfiguration.internal.preferences.PreferenceConstants;
+import org.eclipse.tm4e.languageconfiguration.internal.preferences.PreferenceHelper;
+import org.eclipse.tm4e.languageconfiguration.internal.supports.CharacterPair;
+import org.eclipse.tm4e.ui.utils.ContentTypeHelper;
+import org.eclipse.tm4e.ui.utils.ContentTypeInfo;
+
+public class LanguageConfigurationBracketMatchingReconcilingStrategy
+		implements IReconcilingStrategy, IPreferenceChangeListener, IReconcilingStrategyExtension {
+	public static final String BRACKET_MATCHING_TYPE = "org.eclipse.tm4e.languageconfiguration.bracketmatching"; //$NON-NLS-1$
+	private boolean enabled;
+	private ISourceViewer sourceViewer;
+	private IDocument document;
+	private IContentType[] contentTypes;
+	private final Annotation bracketMatchingAnnotation = new Annotation(BRACKET_MATCHING_TYPE, false, null);
+
+	private void updateAnnotations(ISelection selection) {
+		if (!(selection instanceof ITextSelection)) {
+			removeAnnotation();
+			return;
+		}
+		ITextSelection textSelection = (ITextSelection) selection;
+		IContentType[] contentTypes = findContentTypes(document);
+		if (contentTypes == null) {
+			removeAnnotation();
+			return;
+		}
+		IAnnotationModel annotationModel = sourceViewer.getAnnotationModel();
+		if (annotationModel == null) {
+			removeAnnotation();
+			return;
+		}
+		int offset = textSelection.getOffset();
+		LanguageConfigurationRegistryManager registry = LanguageConfigurationRegistryManager.getInstance();
+		for (IContentType contentType : contentTypes) {
+			if (!registry.shouldSurroundingPairs(document, offset, contentType)) {
+				continue;
+			}
+			List<CharacterPair> surroundingPairs = registry.getSurroundingPairs(contentType);
+			for (CharacterPair surroundingPair : surroundingPairs) {
+				Position positionOfMatchingPair = getPositionOfMatchingPair(document.get(), offset, surroundingPair);
+				if (positionOfMatchingPair != null) {
+					Position oldPosition = annotationModel.getPosition(bracketMatchingAnnotation);
+					if (oldPosition == null || !oldPosition.equals(positionOfMatchingPair)) {
+						removeAnnotation();
+						annotationModel.addAnnotation(bracketMatchingAnnotation, positionOfMatchingPair);
+					}
+					return;
+				}
+			}
+		}
+		removeAnnotation();
+	}
+
+	private Position getPositionOfMatchingPair(String text, int offset, CharacterPair surroundingPair) {
+		String openning = surroundingPair.getKey();
+		String closing = surroundingPair.getValue();
+		int startOfMatchingPair = -1;
+		int lengthOfMatchingPair = -1;
+		int closeSearchStart = offset - closing.length();
+		closeSearchStart = closeSearchStart < 0 ? 0 : closeSearchStart;
+		int closeSearchEnd = offset + closing.length();
+		closeSearchEnd = closeSearchEnd >= text.length() ? text.length() : closeSearchEnd;
+		int indexOfClose = text.substring(closeSearchStart, closeSearchEnd).indexOf(closing);
+		if (indexOfClose != -1) {
+			startOfMatchingPair = findOpenning(text, closeSearchStart + indexOfClose, surroundingPair);
+			lengthOfMatchingPair = closing.length();
+		} else {
+			int openSearchStart = offset - openning.length();
+			openSearchStart = openSearchStart < 0 ? 0 : openSearchStart;
+			int openSearchEnd = offset + openning.length();
+			openSearchEnd = openSearchEnd >= text.length() ? text.length() : openSearchEnd;
+			int indexOfOpen = text.substring(openSearchStart, openSearchEnd).indexOf(openning);
+			if (indexOfOpen != -1) {
+				startOfMatchingPair = findClosing(text, openSearchStart + indexOfOpen, surroundingPair);
+				lengthOfMatchingPair = openning.length();
+			}
+		}
+		if (startOfMatchingPair == -1) {
+			return null;
+		}
+		return new Position(startOfMatchingPair, lengthOfMatchingPair);
+	}
+
+	/**
+	 * Finds the beginning index of the closing that matches the given openning
+	 * index
+	 *
+	 * @param text            of the document
+	 * @param offset          before the openning
+	 * @param surroundingPair the openning, closing pair
+	 * @return the ending index of the closing
+	 */
+	private int findClosing(String text, int offset, CharacterPair surroundingPair) {
+		String openning = surroundingPair.getKey();
+		String closing = surroundingPair.getValue();
+		if (openning.equals(closing)) {
+			return findMatchingforDuplicatePairs(text, offset, openning);
+		}
+		int closeOffset = offset + surroundingPair.getKey().length();
+		int counter = 1;
+		while (counter > 0 && closeOffset <= text.length() + closing.length()) {
+			int nextOpenIndex = text.indexOf(openning, closeOffset);
+			int nextCloseIndex = text.indexOf(closing, closeOffset);
+			if (nextCloseIndex == -1) {
+				break;
+			}
+			if (nextOpenIndex == -1 || nextCloseIndex <= nextOpenIndex) {
+				counter--;
+				closeOffset = nextCloseIndex + closing.length();
+			} else {
+				counter++;
+				closeOffset = nextOpenIndex + openning.length();
+			}
+		}
+		if (counter == 0) {
+			return closeOffset - closing.length();
+		}
+		return -1;
+	}
+
+	/**
+	 * Finds the beginning index of the openning that matches the given openning
+	 * index
+	 *
+	 * @param text            of the document
+	 * @param offset          before the closing
+	 * @param surroundingPair the openning, closing pair
+	 * @return the beginning index of the openning
+	 */
+	private int findOpenning(String text, int offset, CharacterPair surroundingPair) {
+		String openning = surroundingPair.getKey();
+		String closing = surroundingPair.getValue();
+		if (openning.equals(closing)) {
+			return findMatchingforDuplicatePairs(text, offset, openning);
+		}
+		int openOffset = offset;
+		int counter = 1;
+		while (counter > 0 && openOffset >= 0) {
+			int previousOpenIndex = text.lastIndexOf(openning, openOffset - 1);
+			int previousCloseIndex = text.lastIndexOf(closing, openOffset - 1);
+			if (previousOpenIndex == -1 && previousCloseIndex == -1) {
+				break;
+			}
+			if (previousOpenIndex > previousCloseIndex) {
+				counter--;
+				openOffset = previousOpenIndex;
+			} else {
+				counter++;
+				openOffset = previousCloseIndex;
+			}
+		}
+		if (counter == 0) {
+			return openOffset;
+		}
+		return -1;
+	}
+
+	/**
+	 * Finds the beginning index of the matching pair when both of the pairs are the
+	 * same.
+	 *
+	 * @param text     of the document
+	 * @param index    before the current character
+	 * @param instance of the surrounding pair
+	 * @return
+	 */
+	private int findMatchingforDuplicatePairs(String text, int index, String instance) {
+		String prefix = text.substring(0, index);
+		int matchesBeforeIndex = prefix.split(Pattern.quote(instance), -1).length - 1;
+		if (matchesBeforeIndex % 2 == 0) {
+			String suffix = text.substring(index + instance.length(), text.length());
+			int matchIndex = suffix.indexOf(instance);
+			return matchIndex == -1 ? -1 : (matchIndex + index + instance.length());
+		}
+		return prefix.lastIndexOf(instance);
+	}
+
+	private IContentType[] findContentTypes(IDocument document) {
+		if (contentTypes != null && this.document != null && this.document.equals(document)) {
+			return contentTypes;
+		}
+		try {
+			ContentTypeInfo info = ContentTypeHelper.findContentTypes(document);
+			this.contentTypes = info.getContentTypes();
+			this.document = document;
+		} catch (CoreException e) {
+			e.printStackTrace();
+		}
+		return contentTypes;
+	}
+
+	class EditorSelectionChangedListener implements ISelectionChangedListener {
+		public void install(ISelectionProvider selectionProvider) {
+			if (selectionProvider == null) {
+				return;
+			}
+			if (selectionProvider instanceof IPostSelectionProvider) {
+				IPostSelectionProvider provider = (IPostSelectionProvider) selectionProvider;
+				provider.addPostSelectionChangedListener(this);
+			} else {
+				selectionProvider.addSelectionChangedListener(this);
+			}
+		}
+
+		public void uninstall(ISelectionProvider selectionProvider) {
+			if (selectionProvider == null) {
+				return;
+			}
+			if (selectionProvider instanceof IPostSelectionProvider) {
+				IPostSelectionProvider provider = (IPostSelectionProvider) selectionProvider;
+				provider.removePostSelectionChangedListener(this);
+			} else {
+				selectionProvider.removeSelectionChangedListener(this);
+			}
+		}
+
+		@Override
+		public void selectionChanged(SelectionChangedEvent event) {
+			updateAnnotations(event.getSelection());
+		}
+	}
+
+	private EditorSelectionChangedListener editorSelectionChangedListener;
+
+	public void install(ITextViewer viewer) {
+		if (!(viewer instanceof ISourceViewer)) {
+			return;
+		}
+		IEclipsePreferences preferences = InstanceScope.INSTANCE.getNode(LanguageConfigurationPlugin.PLUGIN_ID);
+		preferences.addPreferenceChangeListener(this);
+		this.enabled = preferences.getBoolean(PreferenceConstants.LANGUAGE_CONFIGURATIONS, true);
+		this.sourceViewer = (ISourceViewer) viewer;
+		editorSelectionChangedListener = new EditorSelectionChangedListener();
+		editorSelectionChangedListener.install(sourceViewer.getSelectionProvider());
+	}
+
+	public void uninstall() {
+		if (sourceViewer != null) {
+			editorSelectionChangedListener.uninstall(sourceViewer.getSelectionProvider());
+		}
+		IEclipsePreferences preferences = InstanceScope.INSTANCE.getNode(LanguageConfigurationPlugin.PLUGIN_ID);
+		preferences.removePreferenceChangeListener(this);
+	}
+
+	@Override
+	public void setDocument(IDocument document) {
+		this.document = document;
+	}
+
+	@Override
+	public void preferenceChange(PreferenceChangeEvent event) {
+		if (event.getKey().equals(PreferenceConstants.LANGUAGE_CONFIGURATIONS)) {
+			ILanguageConfigurationDefinition[] definitions = PreferenceHelper
+					.loadLanguageConfigurationDefinitions(event.getNewValue().toString());
+			List<IContentType> contentTypes = Arrays.asList(findContentTypes(document));
+			this.enabled = false;
+			if (contentTypes != null) {
+				for (ILanguageConfigurationDefinition definition : definitions) {
+					if (contentTypes.contains(definition.getContentType())
+							&& definition.isBracketAutoClosingEnabled()) {
+						this.enabled = true;
+						break;
+					}
+				}
+			}
+			if (enabled) {
+				initialReconcile();
+			} else {
+				removeAnnotation();
+			}
+		}
+	}
+
+	void removeAnnotation() {
+		IAnnotationModel annotationModel = sourceViewer.getAnnotationModel();
+		if (annotationModel == null) {
+			return;
+		}
+		annotationModel.removeAnnotation(bracketMatchingAnnotation);
+	}
+
+	@Override
+	public void setProgressMonitor(IProgressMonitor monitor) {
+		// Do nothing
+	}
+
+	@Override
+	public void reconcile(DirtyRegion dirtyRegion, IRegion subRegion) {
+		// Do nothing
+	}
+
+	@Override
+	public void reconcile(IRegion partition) {
+		// Do nothing
+	}
+
+	@Override
+	public void initialReconcile() {
+		if (sourceViewer != null) {
+			ISelectionProvider selectionProvider = sourceViewer.getSelectionProvider();
+			final StyledText textWidget = sourceViewer.getTextWidget();
+			if (textWidget != null && selectionProvider != null) {
+				textWidget.getDisplay().asyncExec(() -> {
+					if (!textWidget.isDisposed()) {
+						updateAnnotations(selectionProvider.getSelection());
+					}
+				});
+			}
+		}
+	}
+}

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/LanguageConfigurationRegistryManager.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/LanguageConfigurationRegistryManager.java
@@ -91,6 +91,23 @@ public class LanguageConfigurationRegistryManager extends AbstractLanguageConfig
 		return characterPairSupport != null && characterPairSupport.shouldAutoClosePair(character);
 	}
 
+	public List<CharacterPair> getSurroundingPairs(IContentType contentType) {
+		CharacterPairSupport characterPairSupport = this._getCharacterPairSupport(contentType);
+		if (characterPairSupport == null) {
+			return Collections.emptyList();
+		}
+		return characterPairSupport.getSurroundingPairs();
+	}
+
+	public boolean shouldSurroundingPairs(IDocument document, int offset, IContentType contentType) {
+		LanguageConfigurationDefinition definition = getDefinition(contentType);
+		if (definition == null || !definition.isMatchingPairsEnabled()) {
+			return false;
+		}
+		CharacterPairSupport characterPairSupport = this._getCharacterPairSupport(contentType);
+		return characterPairSupport != null;
+	}
+
 	public EnterActionAndIndent getEnterAction(IDocument document, int offset, IContentType contentType) {
 		String indentation = TextUtils.getIndentationAtPosition(document, offset);
 		// let scopedLineTokens = this.getScopedLineTokens(model, range.startLineNumber,

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/supports/CharacterPairSupport.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/supports/CharacterPairSupport.java
@@ -54,4 +54,8 @@ public class CharacterPairSupport {
 	public List<CharacterPair> getAutoClosingPairs() {
 		return autoClosingPairs;
 	}
+
+	public List<CharacterPair> getSurroundingPairs() {
+		return surroundingPairs;
+	}
 }


### PR DESCRIPTION
 - Enable bracket matching using the surroundingPairs in the language-configuration.json file
 - KNOWN ISSUE: Does not take in account "back slashed" or in string matched pairs
   - ex: {"}"} will match the first }
   - ex: "\\"" will match the first two "

Signed-off-by: Lucas Bullen <lbullen@redhat.com>