### PR TITLE
Issue #174 Contextual menu for comments commands

### DIFF
--- a/org.eclipse.tm4e.languageconfiguration/plugin.xml
+++ b/org.eclipse.tm4e.languageconfiguration/plugin.xml
@@ -141,39 +141,21 @@
            class="org.eclipse.tm4e.languageconfiguration.ToggleLineCommentHandler"
            commandId="org.eclipse.tm4e.languageconfiguration.togglelinecommentcommand">
         <enabledWhen>
-           <with
-                 variable="activeEditor">
-              <test
-                    property="org.eclipse.tm4e.languageconfiguration.hasLanguageConfiguration"
-                    forcePluginActivation="true">
-              </test>
-           </with>
+           <reference definitionId="org.eclipse.tm4e.languageconfiguration.hasLanguageConfiguration"/>
         </enabledWhen>
      </handler>
      <handler
            class="org.eclipse.tm4e.languageconfiguration.ToggleLineCommentHandler"
            commandId="org.eclipse.tm4e.languageconfiguration.addblockcommentcommand">
         <enabledWhen>
-           <with
-                 variable="activeEditor">
-              <test
-                    property="org.eclipse.tm4e.languageconfiguration.hasLanguageConfiguration"
-                    forcePluginActivation="true">
-              </test>
-           </with>
+           <reference definitionId="org.eclipse.tm4e.languageconfiguration.hasLanguageConfiguration"/>
         </enabledWhen>
      </handler>
      <handler
            class="org.eclipse.tm4e.languageconfiguration.ToggleLineCommentHandler"
            commandId="org.eclipse.tm4e.languageconfiguration.removeblockcommentcommand">
         <enabledWhen>
-           <with
-                 variable="activeEditor">
-              <test
-                    property="org.eclipse.tm4e.languageconfiguration.hasLanguageConfiguration"
-                    forcePluginActivation="true">
-              </test>
-           </with>
+           <reference definitionId="org.eclipse.tm4e.languageconfiguration.hasLanguageConfiguration"/>
         </enabledWhen>
      </handler>
   </extension>
@@ -187,4 +169,45 @@
            type="java.lang.Object">
      </propertyTester>
   </extension>
+  <extension
+        point="org.eclipse.ui.menus">
+     <menuContribution
+           allPopups="true"
+       locationURI="popup:org.eclipse.ui.genericeditor.source.menu?after=additions">
+       <command
+             commandId="org.eclipse.tm4e.languageconfiguration.togglelinecommentcommand"
+             style="push">
+          <visibleWhen>
+             <reference definitionId="org.eclipse.tm4e.languageconfiguration.hasLanguageConfiguration"/>
+          </visibleWhen>
+       </command>
+       <command
+             commandId="org.eclipse.tm4e.languageconfiguration.addblockcommentcommand"
+             style="push">
+          <visibleWhen>
+             <reference definitionId="org.eclipse.tm4e.languageconfiguration.hasLanguageConfiguration"/>
+          </visibleWhen>
+       </command>
+       <command
+             commandId="org.eclipse.tm4e.languageconfiguration.removeblockcommentcommand"
+             style="push">
+          <visibleWhen>
+             <reference definitionId="org.eclipse.tm4e.languageconfiguration.hasLanguageConfiguration"/>
+          </visibleWhen>
+       </command>
+     </menuContribution>
+  </extension>
+   <extension
+         point="org.eclipse.core.expressions.definitions">
+      <definition
+            id="org.eclipse.tm4e.languageconfiguration.hasLanguageConfiguration">
+         <with
+               variable="activeEditor">
+            <test
+                  property="org.eclipse.tm4e.languageconfiguration.hasLanguageConfiguration"
+                  forcePluginActivation="true">
+            </test>
+         </with>
+      </definition>
+   </extension>
 </plugin>

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/LanguageConfigurationAutoEditStrategy.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/LanguageConfigurationAutoEditStrategy.java
@@ -66,7 +66,7 @@ public class LanguageConfigurationAutoEditStrategy implements IAutoEditStrategy 
 				continue;
 			}
 			command.text += autoClosingPair.getValue();
-			command.caretOffset = command.offset + autoClosingPair.getValue().length();
+			command.caretOffset = command.offset + 1;
 			command.shiftsCaret = false;
 			break;
 		}


### PR DESCRIPTION
 - Relies on https://git.eclipse.org/r/#/c/128034/
 - Creates popup option for the comment commands for users to quickly
see the key activation sequences of each command
 - Fixes small issue with mulit-char auto inserts moving the caret too
far

Signed-off-by: Lucas Bullen <lbullen@redhat.com>