### PR TITLE
Issue #163: Support another dark themes

### DIFF
--- a/org.eclipse.tm4e.ui/plugin.properties
+++ b/org.eclipse.tm4e.ui/plugin.properties
@@ -14,6 +14,7 @@ providerName=Eclipse TM4E
 # Extension Points
 Themes.extension.name=TextMate themes provider extension point.
 Snippets.extension.name=Snippets provider extension point.
+ThemeBehaviour.extension.name=TextMate theme behaviour provider extension point.
 
 # Default theme names
 Theme.Light.name=Light

--- a/org.eclipse.tm4e.ui/plugin.xml
+++ b/org.eclipse.tm4e.ui/plugin.xml
@@ -20,6 +20,9 @@
    <extension-point id="snippets" 
                        name="%Snippets.extension.name"
                     schema="schema/snippets.exsd" />
+   <extension-point id="themeBehaviour"
+   					   name="%ThemeBehaviour.extension.name"
+   					schema="schema/themeBehaviour.exsd" />
                     
    <!-- Register default TextMate Themes -->
    <extension

--- a/org.eclipse.tm4e.ui/schema/themeBehaviour.exsd
+++ b/org.eclipse.tm4e.ui/schema/themeBehaviour.exsd
@@ -1,0 +1,53 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="org.eclipse.tm4e.ui" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appinfo>
+         <meta.schema plugin="org.eclipse.tm4e.ui" id="theme_behavior" name="TextMate theme behaviour"/>
+      </appinfo>
+      <documentation>
+         Extension point to register themes behaviour when changing general color theme.
+      </documentation>
+   </annotation>
+
+   <element name="behaviour">
+      <annotation>
+         <documentation>
+            This extension point allows developers to register themes behaviour.
+         </documentation>
+      </annotation>
+      <complexType>
+         <attribute name="name" type="string" use="required">
+            <annotation>
+               <documentation>
+                  The behaviour name.
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="class" type="string" use="required">
+            <annotation>
+               <documentation>
+                  Provides a way to programmatically specify theme behaviour.
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn=":org.eclipse.tm4e.ui.themes.IThemeBehaviour"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="since"/>
+      </appinfo>
+      <documentation>
+         2.0
+      </documentation>
+   </annotation>
+
+
+
+
+
+</schema>

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/TMUIPlugin.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/TMUIPlugin.java
@@ -12,6 +12,7 @@ package org.eclipse.tm4e.ui;
 
 import org.eclipse.tm4e.ui.internal.model.TMModelManager;
 import org.eclipse.tm4e.ui.internal.snippets.SnippetManager;
+import org.eclipse.tm4e.ui.internal.themes.ThemeBehaviourManager;
 import org.eclipse.tm4e.ui.internal.themes.ThemeManager;
 import org.eclipse.tm4e.ui.model.ITMModelManager;
 import org.eclipse.tm4e.ui.snippets.ISnippetManager;
@@ -40,6 +41,7 @@ public class TMUIPlugin extends AbstractUIPlugin {
 	@Override
 	public void start(BundleContext context) throws Exception {
 		super.start(context);
+		ThemeBehaviourManager.getInstance().init();
 		plugin = this;
 	}
 
@@ -84,6 +86,15 @@ public class TMUIPlugin extends AbstractUIPlugin {
 	 */
 	public static ISnippetManager getSnippetManager() {
 		return SnippetManager.getInstance();
+	}
+
+	/**
+	 * Returns the ThemeBehaviour manager
+	 * 
+	 * @return the ThemeBehaviour manager
+	 */
+	public static ThemeBehaviourManager getThemeBehaviourManager() {
+		return ThemeBehaviourManager.getInstance();
 	}
 
 }

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/menus/ThemeContribution.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/menus/ThemeContribution.java
@@ -22,6 +22,7 @@ import org.eclipse.tm4e.ui.TMUIPlugin;
 import org.eclipse.tm4e.ui.text.TMPresentationReconciler;
 import org.eclipse.tm4e.ui.themes.ITheme;
 import org.eclipse.tm4e.ui.themes.IThemeAssociation;
+import org.eclipse.tm4e.ui.themes.IThemeBehaviour;
 import org.eclipse.tm4e.ui.themes.IThemeManager;
 import org.eclipse.tm4e.ui.themes.ThemeAssociation;
 import org.eclipse.ui.IEditorPart;
@@ -47,12 +48,13 @@ public class ThemeContribution extends CompoundContributionItem implements IWork
 
 	@Override
 	protected IContributionItem[] getContributionItems() {
-		List<IContributionItem> items = new ArrayList<IContributionItem>();
+		List<IContributionItem> items = new ArrayList<>();
 		if (handlerService != null) {
 			IEditorPart editorPart = getActivePart(handlerService.getCurrentState());
 			if (editorPart != null) {
 				IThemeManager manager = TMUIPlugin.getThemeManager();
-				boolean dark = manager.isDarkEclipseTheme();
+				IThemeBehaviour behaviour = TMUIPlugin.getThemeBehaviourManager().getThemeBehaviour();
+				boolean dark = behaviour.isDarkEclipseTheme();
 				ITheme[] themes = manager.getThemes();
 				if (themes != null) {
 					String scopeName = TMPresentationReconciler.getTMPresentationReconciler(editorPart).getGrammar()

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/preferences/PreferenceConstants.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/preferences/PreferenceConstants.java
@@ -17,7 +17,9 @@ package org.eclipse.tm4e.ui.internal.preferences;
 public class PreferenceConstants {
 
 	public static final String THEMES = "org.eclipse.tm4e.ui.themes";
-	
+
 	public static final String THEME_ASSOCIATIONS = "org.eclipse.tm4e.ui.themeAssociations";
+
+	public static final String E4_THEME_ID = "themeid";
 
 }

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/themes/AbstractThemeManager.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/themes/AbstractThemeManager.java
@@ -17,10 +17,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.eclipse.core.runtime.preferences.IEclipsePreferences;
-import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.tm4e.ui.TMUIPlugin;
 import org.eclipse.tm4e.ui.themes.ITheme;
 import org.eclipse.tm4e.ui.themes.IThemeAssociation;
+import org.eclipse.tm4e.ui.themes.IThemeBehaviour;
 import org.eclipse.tm4e.ui.themes.IThemeManager;
 import org.eclipse.tm4e.ui.themes.ThemeAssociation;
 
@@ -30,19 +30,14 @@ import org.eclipse.tm4e.ui.themes.ThemeAssociation;
  */
 public abstract class AbstractThemeManager implements IThemeManager {
 
-	// Theme for E4 CSS Engine
-	public static final String E4_THEME_ID = "themeid"; //$NON-NLS-1$
-
-	private static final String E4_CSS_THEME_PREFERENCE_ID = "org.eclipse.e4.ui.css.swt.theme"; //$NON-NLS-1$
-	private static final String E4_DARK = "org.eclipse.e4.ui.css.theme.e4_dark";
-	private static final String DEVSTYLE_DARK = "com.genuitec.eclipse.themes.dark";
-
+	private final IThemeBehaviour behaviour;
 	private final Map<String /* theme id */ , ITheme> themes;
 	private final ThemeAssociationRegistry themeAssociationRegistry;
 
 	public AbstractThemeManager() {
 		this.themes = new LinkedHashMap<>();
 		this.themeAssociationRegistry = new ThemeAssociationRegistry();
+		this.behaviour = TMUIPlugin.getThemeBehaviourManager().getThemeBehaviour();
 	}
 
 	@Override
@@ -68,7 +63,7 @@ public abstract class AbstractThemeManager implements IThemeManager {
 
 	@Override
 	public ITheme getDefaultTheme() {
-		boolean dark = isDarkEclipseTheme();
+		boolean dark = behaviour.isDarkEclipseTheme();
 		return getDefaultTheme(dark);
 	}
 
@@ -90,30 +85,6 @@ public abstract class AbstractThemeManager implements IThemeManager {
 	}
 
 	@Override
-	public String getPreferenceE4CSSThemeId() {
-		IEclipsePreferences preferences = getPreferenceE4CSSTheme();
-		return preferences != null ? preferences.get(E4_THEME_ID, null) : null;
-	}
-
-	protected boolean isDarkDevStyleTheme(String themeId) {
-		return themeId.contains(DEVSTYLE_DARK);
-	}
-
-	@Override
-	public boolean isDarkEclipseTheme() {
-		return isDarkEclipseTheme(getPreferenceE4CSSThemeId());
-	}
-
-	@Override
-	public boolean isDarkEclipseTheme(String eclipseThemeId) {
-		return eclipseThemeId.contains(E4_DARK) || isDarkDevStyleTheme(eclipseThemeId);
-	}
-
-	protected IEclipsePreferences getPreferenceE4CSSTheme() {
-		return InstanceScope.INSTANCE.getNode(E4_CSS_THEME_PREFERENCE_ID);
-	}
-
-	@Override
 	public ITheme getThemeForScope(String scopeName, boolean dark) {
 		IThemeAssociation association = themeAssociationRegistry.getThemeAssociationFor(scopeName, dark);
 		if (association != null) {
@@ -125,7 +96,7 @@ public abstract class AbstractThemeManager implements IThemeManager {
 
 	@Override
 	public ITheme getThemeForScope(String scopeName) {
-		return getThemeForScope(scopeName, isDarkEclipseTheme());
+		return getThemeForScope(scopeName, behaviour.isDarkEclipseTheme());
 	}
 
 	@Override

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/themes/AbstractThemeManager.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/themes/AbstractThemeManager.java
@@ -31,9 +31,11 @@ import org.eclipse.tm4e.ui.themes.ThemeAssociation;
 public abstract class AbstractThemeManager implements IThemeManager {
 
 	// Theme for E4 CSS Engine
-	private static final String E4_CSS_THEME_PREFERENCE_ID = "org.eclipse.e4.ui.css.swt.theme"; //$NON-NLS-1$
 	public static final String E4_THEME_ID = "themeid"; //$NON-NLS-1$
-	private final static String E4_DARK = "org.eclipse.e4.ui.css.theme.e4_dark";
+
+	private static final String E4_CSS_THEME_PREFERENCE_ID = "org.eclipse.e4.ui.css.swt.theme"; //$NON-NLS-1$
+	private static final String E4_DARK = "org.eclipse.e4.ui.css.theme.e4_dark";
+	private static final String DEVSTYLE_DARK = "com.genuitec.eclipse.themes.dark";
 
 	private final Map<String /* theme id */ , ITheme> themes;
 	private final ThemeAssociationRegistry themeAssociationRegistry;
@@ -93,6 +95,10 @@ public abstract class AbstractThemeManager implements IThemeManager {
 		return preferences != null ? preferences.get(E4_THEME_ID, null) : null;
 	}
 
+	protected boolean isDarkDevStyleTheme(String themeId) {
+		return themeId.contains(DEVSTYLE_DARK);
+	}
+
 	@Override
 	public boolean isDarkEclipseTheme() {
 		return isDarkEclipseTheme(getPreferenceE4CSSThemeId());
@@ -100,7 +106,7 @@ public abstract class AbstractThemeManager implements IThemeManager {
 
 	@Override
 	public boolean isDarkEclipseTheme(String eclipseThemeId) {
-		return E4_DARK.equals(eclipseThemeId);
+		return E4_DARK.equals(eclipseThemeId) || isDarkDevStyleTheme(eclipseThemeId);
 	}
 
 	protected IEclipsePreferences getPreferenceE4CSSTheme() {

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/themes/AbstractThemeManager.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/themes/AbstractThemeManager.java
@@ -106,7 +106,7 @@ public abstract class AbstractThemeManager implements IThemeManager {
 
 	@Override
 	public boolean isDarkEclipseTheme(String eclipseThemeId) {
-		return E4_DARK.equals(eclipseThemeId) || isDarkDevStyleTheme(eclipseThemeId);
+		return eclipseThemeId.contains(E4_DARK) || isDarkDevStyleTheme(eclipseThemeId);
 	}
 
 	protected IEclipsePreferences getPreferenceE4CSSTheme() {

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/themes/DefaultThemeBehaviour.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/themes/DefaultThemeBehaviour.java
@@ -1,0 +1,20 @@
+package org.eclipse.tm4e.ui.internal.themes;
+
+import org.eclipse.tm4e.ui.themes.IThemeBehaviour;
+import org.eclipse.tm4e.ui.utils.PreferenceUtils;
+
+public class DefaultThemeBehaviour implements IThemeBehaviour {
+
+	private static final String E4_DARK = "org.eclipse.e4.ui.css.theme.e4_dark";
+
+	@Override
+	public boolean isDarkEclipseTheme() {
+		return isDarkEclipseTheme(PreferenceUtils.getPreferenceE4CSSThemeId());
+	}
+
+	@Override
+	public boolean isDarkEclipseTheme(String eclipseThemeId) {
+		return E4_DARK.equals(eclipseThemeId);
+	}
+
+}

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/themes/ThemeBehaviourManager.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/themes/ThemeBehaviourManager.java
@@ -1,0 +1,62 @@
+package org.eclipse.tm4e.ui.internal.themes;
+
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.tm4e.ui.TMUIPlugin;
+import org.eclipse.tm4e.ui.themes.IThemeBehaviour;
+
+public class ThemeBehaviourManager {
+
+	private static final String EXTENSION_POINT_NAME = TMUIPlugin.PLUGIN_ID + ".themeBehaviour";
+	private static ThemeBehaviourManager INSTANCE = new ThemeBehaviourManager();
+
+	private IThemeBehaviour behaviour;
+
+	private ThemeBehaviourManager() {
+	}
+
+	public static ThemeBehaviourManager getInstance() {
+		return INSTANCE;
+	}
+
+	public IThemeBehaviour getThemeBehaviour() {
+		return behaviour;
+	}
+
+	/**
+	 * Initialize manager
+	 */
+	public void init() {
+		IConfigurationElement[] configurationElements = Platform.getExtensionRegistry()
+				.getConfigurationElementsFor(EXTENSION_POINT_NAME);
+
+		if (configurationElements.length > 0) {
+			behaviour = getBehaviour(configurationElements[0]);
+		}
+
+		if (behaviour == null) {
+			behaviour = new DefaultThemeBehaviour();
+		}
+	}
+
+	/**
+	 * Get behaviour from extension point.
+	 * 
+	 * @param element
+	 *            configurationElement for extension point
+	 * @return behaviour from configuration or null if exception occured
+	 */
+	private IThemeBehaviour getBehaviour(IConfigurationElement element) {
+		IThemeBehaviour extendedBehaviour = null;
+		String className = element.getAttribute("class");
+		String bundleName = element.getContributor().getName();
+		try {
+			Class<?> clazz = Platform.getBundle(bundleName).loadClass(className);
+			extendedBehaviour = (IThemeBehaviour) clazz.newInstance();
+		} catch (ClassNotFoundException | InstantiationException | IllegalAccessException e1) {
+			// ignore
+		}
+
+		return extendedBehaviour;
+	}
+}

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/themes/ThemeBehaviourManager.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/themes/ThemeBehaviourManager.java
@@ -1,5 +1,6 @@
 package org.eclipse.tm4e.ui.internal.themes;
 
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.tm4e.ui.TMUIPlugin;
@@ -44,19 +45,16 @@ public class ThemeBehaviourManager {
 	 * 
 	 * @param element
 	 *            configurationElement for extension point
-	 * @return behaviour from configuration or null if exception occured
+	 * @return behaviour from configuration or default behaviour if exception occured
 	 */
 	private IThemeBehaviour getBehaviour(IConfigurationElement element) {
-		IThemeBehaviour extendedBehaviour = null;
-		String className = element.getAttribute("class");
-		String bundleName = element.getContributor().getName();
 		try {
-			Class<?> clazz = Platform.getBundle(bundleName).loadClass(className);
-			extendedBehaviour = (IThemeBehaviour) clazz.newInstance();
-		} catch (ClassNotFoundException | InstantiationException | IllegalAccessException e1) {
+			return (IThemeBehaviour) element.createExecutableExtension("class");
+		} catch (CoreException ex) {
 			// ignore
 		}
 
-		return extendedBehaviour;
+		return null;
+
 	}
 }

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/themes/ThemeBehaviourManager.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/themes/ThemeBehaviourManager.java
@@ -45,7 +45,7 @@ public class ThemeBehaviourManager {
 	 * 
 	 * @param element
 	 *            configurationElement for extension point
-	 * @return behaviour from configuration or default behaviour if exception occured
+	 * @return behaviour from configuration or null if exception occured
 	 */
 	private IThemeBehaviour getBehaviour(IConfigurationElement element) {
 		try {

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/themes/ThemeManager.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/themes/ThemeManager.java
@@ -25,6 +25,7 @@ import org.eclipse.tm4e.ui.themes.ITheme;
 import org.eclipse.tm4e.ui.themes.IThemeAssociation;
 import org.eclipse.tm4e.ui.themes.Theme;
 import org.eclipse.tm4e.ui.themes.ThemeAssociation;
+import org.eclipse.tm4e.ui.utils.PreferenceUtils;
 import org.osgi.service.prefs.BackingStoreException;
 
 /**
@@ -138,7 +139,7 @@ public class ThemeManager extends AbstractThemeManager {
 	 */
 	public void addPreferenceChangeListener(IPreferenceChangeListener themeChangeListener) {
 		// Observe change of Eclipse E4 Theme
-		IEclipsePreferences preferences = getPreferenceE4CSSTheme();
+		IEclipsePreferences preferences = PreferenceUtils.getE4PreferenceStore();
 		if (preferences != null) {
 			preferences.addPreferenceChangeListener(themeChangeListener);
 		}
@@ -157,7 +158,7 @@ public class ThemeManager extends AbstractThemeManager {
 	 */
 	public void removePreferenceChangeListener(IPreferenceChangeListener themeChangeListener) {
 		// Observe change of Eclipse E4 Theme
-		IEclipsePreferences preferences = getPreferenceE4CSSTheme();
+		IEclipsePreferences preferences = PreferenceUtils.getE4PreferenceStore();
 		if (preferences != null) {
 			preferences.removePreferenceChangeListener(themeChangeListener);
 		}

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/text/TMPresentationReconciler.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/text/TMPresentationReconciler.java
@@ -73,11 +73,13 @@ import org.eclipse.tm4e.ui.internal.themes.ThemeManager;
 import org.eclipse.tm4e.ui.internal.wizards.TextMateGrammarImportWizard;
 import org.eclipse.tm4e.ui.model.ITMModelManager;
 import org.eclipse.tm4e.ui.themes.ITheme;
+import org.eclipse.tm4e.ui.themes.IThemeBehaviour;
 import org.eclipse.tm4e.ui.themes.IThemeManager;
 import org.eclipse.tm4e.ui.themes.ITokenProvider;
 import org.eclipse.tm4e.ui.utils.ClassHelper;
 import org.eclipse.tm4e.ui.utils.ContentTypeHelper;
 import org.eclipse.tm4e.ui.utils.ContentTypeInfo;
+import org.eclipse.tm4e.ui.utils.PreferenceUtils;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.PlatformUI;
 
@@ -163,13 +165,16 @@ public class TMPresentationReconciler implements IPresentationReconciler {
 	 */
 	private class ThemeChangeListener implements IPreferenceChangeListener {
 
+		protected IThemeBehaviour behaviour = TMUIPlugin.getThemeBehaviourManager().getThemeBehaviour();
+
 		@Override
 		public void preferenceChange(PreferenceChangeEvent event) {
 			IThemeManager themeManager = TMUIPlugin.getThemeManager();
-			if (ThemeManager.E4_THEME_ID.equals(event.getKey())) {
+
+			if (PreferenceConstants.E4_THEME_ID.equals(event.getKey())) {
 				preferenceThemeChange((String) event.getNewValue(), themeManager);
 			} else if (PreferenceConstants.THEME_ASSOCIATIONS.equals(event.getKey())) {
-				preferenceThemeChange(themeManager.getPreferenceE4CSSThemeId(), themeManager);
+				preferenceThemeChange(PreferenceUtils.getPreferenceE4CSSThemeId(), themeManager);
 			}
 		}
 
@@ -188,7 +193,7 @@ public class TMPresentationReconciler implements IPresentationReconciler {
 			}
 			ITokenProvider oldTheme = tokenProvider;
 			// Select the well TextMate theme from the given E4 theme id.
-			boolean dark = themeManager.isDarkEclipseTheme(eclipseThemeId);
+			boolean dark = behaviour.isDarkEclipseTheme(eclipseThemeId);
 			ITokenProvider newTheme = themeManager.getThemeForScope(grammar.getScopeName(), dark);
 			themeChange(oldTheme, newTheme, document);
 		}
@@ -310,7 +315,7 @@ public class TMPresentationReconciler implements IPresentationReconciler {
 					}
 				}
 			} else { // TextViewer#invalidateTextPresentation is called (because
-						// of validation, folding, etc)
+					 // of validation, folding, etc)
 				// case 2), do the colorization.
 				IDocument document = viewer.getDocument();
 				if (document != null) {

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/themes/IThemeBehaviour.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/themes/IThemeBehaviour.java
@@ -1,0 +1,27 @@
+package org.eclipse.tm4e.ui.themes;
+
+/**
+ * API to identify dark or light color scheme applied.
+ * 
+ * Motivation: get the opportunity to influence the applying TM themes behavior depending on the eclipse theme.
+ * 
+ * @author Tim Kovalyov
+ *
+ */
+public interface IThemeBehaviour {
+
+	/**
+	 * Return is current eclipse theme dark or not
+	 */
+	boolean isDarkEclipseTheme();
+
+	/**
+	 * Return is given eclipse theme dark or not
+	 * 
+	 * @param eclipseThemeId
+	 *            given eclipse theme
+	 * @return boolean
+	 */
+	boolean isDarkEclipseTheme(String eclipseThemeId);
+
+}

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/themes/IThemeManager.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/themes/IThemeManager.java
@@ -121,20 +121,10 @@ public interface IThemeManager {
 	IThemeAssociation[] getThemeAssociationsForScope(String scopeName);
 
 	/**
-	 * Returns the Eclipse E4 CSS Theme Id.
-	 * 
-	 * @return the Eclipse E4 CSS Theme Id.
-	 */
-	String getPreferenceE4CSSThemeId();
-
-	/**
 	 * Save the themes definitions.
 	 * 
 	 * @throws BackingStoreException
 	 */
 	void save() throws BackingStoreException;
 
-	boolean isDarkEclipseTheme();
-
-	boolean isDarkEclipseTheme(String eclipseThemeId);
 }

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/utils/PreferenceUtils.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/utils/PreferenceUtils.java
@@ -1,0 +1,36 @@
+package org.eclipse.tm4e.ui.utils;
+
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.tm4e.ui.internal.preferences.PreferenceConstants;
+
+/**
+ * Preference store utilities
+ *
+ */
+public class PreferenceUtils {
+	private static final String E4_CSS_PREFERENCE_NAME = "org.eclipse.e4.ui.css.swt.theme";
+
+	private PreferenceUtils() {
+	}
+
+	/**
+	 * Get e4 preference store
+	 * 
+	 * @return preference store
+	 */
+	public static IEclipsePreferences getE4PreferenceStore() {
+		return InstanceScope.INSTANCE.getNode(E4_CSS_PREFERENCE_NAME);
+	}
+
+	/**
+	 * Get Id of the current eclipse theme
+	 * 
+	 * @return themeIf of the current eclipse theme
+	 */
+	public static String getPreferenceE4CSSThemeId() {
+		IEclipsePreferences preferences = getE4PreferenceStore();
+		return preferences != null ? preferences.get(PreferenceConstants.E4_THEME_ID, null) : null;
+	}
+
+}


### PR DESCRIPTION
Hello! 
I add support for devStyle and OS-dependent dark themes, so now themes correctly switch from light to dark and back. 