### PR TITLE
Fix maven compilation errors

### DIFF
--- a/org.eclipse.tm4e.ui.tests/src/test/java/org/eclipse/tm4e/ui/themes/TMEditorColorTest.java
+++ b/org.eclipse.tm4e.ui.tests/src/test/java/org/eclipse/tm4e/ui/themes/TMEditorColorTest.java
@@ -15,7 +15,6 @@ import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.tm4e.ui.TMUIPlugin;
-import org.eclipse.tm4e.ui.internal.preferences.PreferenceConstants;
 import org.eclipse.ui.IEditorDescriptor;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.PartInitException;
@@ -30,8 +29,9 @@ import org.junit.Test;
 
 public class TMEditorColorTest implements ThemeIdConstants {
 
-	private IThemeManager manager;
+	private static final String EDITOR_CURRENTLINE_HIGHLIGHT = "currentLineColor";
 
+	private IThemeManager manager;
 	private IEditorDescriptor editorDescriptor;
 	private File f;
 	private IEditorPart editor;
@@ -74,7 +74,7 @@ public class TMEditorColorTest implements ThemeIdConstants {
 		assertNull("System default selection foreground should be null", theme.getEditorSelectionForeground());
 
 		Color lineHighlight = ColorManager.getInstance()
-				.getPreferenceEditorColor(PreferenceConstants.EDITOR_CURRENTLINE_HIGHLIGHT);
+				.getPreferenceEditorColor(EDITOR_CURRENTLINE_HIGHLIGHT);
 		assertNotNull("Highlight shouldn't be a null", theme.getEditorCurrentLineHighlight());
 		assertNotEquals("Default Line highlight should be from TM theme", lineHighlight,
 				theme.getEditorCurrentLineHighlight());
@@ -110,7 +110,7 @@ public class TMEditorColorTest implements ThemeIdConstants {
 		assertNull("Selection foreground should be System default (null)", theme.getEditorSelectionForeground());
 
 		Color lineHighlight = ColorManager.getInstance()
-				.getPreferenceEditorColor(PreferenceConstants.EDITOR_CURRENTLINE_HIGHLIGHT);
+				.getPreferenceEditorColor(EDITOR_CURRENTLINE_HIGHLIGHT);
 		assertNotNull("Highlight shouldn't be a null", lineHighlight);
 		assertEquals("Line highlight should be from preferences (because of user defined background)", lineHighlight,
 				theme.getEditorCurrentLineHighlight());

--- a/org.eclipse.tm4e.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.ui/META-INF/MANIFEST.MF
@@ -15,7 +15,8 @@ Require-Bundle: org.eclipse.tm4e.core,
  org.eclipse.ui.ide;resolution:=optional,
  com.google.gson,
  org.eclipse.e4.ui.css.swt.theme,
- org.eclipse.core.expressions
+ org.eclipse.core.expressions,
+ org.eclipse.ui.workbench.texteditor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.tm4e.ui,
  org.eclipse.tm4e.ui.internal.model;x-friends:="org.eclipse.tm4e.ui.tests",
@@ -27,6 +28,5 @@ Export-Package: org.eclipse.tm4e.ui,
  org.eclipse.tm4e.ui.utils
 Bundle-Activator: org.eclipse.tm4e.ui.TMUIPlugin
 Bundle-ActivationPolicy: lazy
-Import-Package: org.eclipse.core.filebuffers,
- org.eclipse.ui.texteditor
+Import-Package: org.eclipse.core.filebuffers
 


### PR DESCRIPTION
I made some mistakes in #188 after which maven package goal failed with compilation errors.
One of this u can see here: [Travis CI build #441](https://travis-ci.org/eclipse/tm4e/builds/454867273?utm_source=github_status&utm_medium=notification) 
and another is a bad import of constant that I fixed.


Signed-off-by: Aloomenon <Aloomenon@gmail.com>