### PR TITLE
Issue #192 - Ignore insertion of repeated closing char

### DIFF
--- a/org.eclipse.tm4e.languageconfiguration.tests/src/org/eclipse/tm4e/languageconfiguration/tests/TestAutoClosing.java
+++ b/org.eclipse.tm4e.languageconfiguration.tests/src/org/eclipse/tm4e/languageconfiguration/tests/TestAutoClosing.java
@@ -59,5 +59,10 @@ public class TestAutoClosing {
 		text.replaceTextRange(0, 0, "(");
 		Assert.assertEquals("()", text.getText());
 		Assert.assertEquals(1, text.getSelection().x);
+		// ignore already closed
+		text.setText("()");
+		text.replaceTextRange(1, 0, ")");
+		Assert.assertEquals("()", text.getText());
+		Assert.assertEquals(2, text.getSelection().x);
 	}
 }

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/LanguageConfigurationAutoEditStrategy.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/LanguageConfigurationAutoEditStrategy.java
@@ -76,32 +76,20 @@ public class LanguageConfigurationAutoEditStrategy implements IAutoEditStrategy 
 			} else {
 				command.text += autoClosingPair.getValue();
 			}
-			break;
+			return;
 		}
 
-		// ITMModel model = TMUIPlugin.getTMModelManager().connect(document);
-		// try {
-		// int lineNumber = document.getLineOfOffset(command.offset);
-		// model.forceTokenization(lineNumber);
-		// List<TMToken> tokens = model.getLineTokens(lineNumber);
-		// System.err.println(tokens.size());
-		// } catch (BadLocationException e) {
-		// // TODO Auto-generated catch block
-		// e.printStackTrace();
-		// }
+		Arrays.stream(contentTypes)
+			.flatMap(contentType -> registry.getAutoClosingPairs(contentType).stream())
+			.map(CharacterPair::getValue)
+			.filter(command.text::equals)
+			.findFirst()
+			.ifPresent(closing -> {
+				command.caretOffset = command.offset + command.text.length();
+				command.shiftsCaret = false;
+				command.text = "";
+			});
 
-		// if (registry.shouldAutoClosePair(command.text, ".java")) {
-		// List<IAutoClosingPair> autoClosingPairs =
-		// registry.getAutoClosingPairs(".java");
-		// for (IAutoClosingPair autoClosingPair : autoClosingPairs) {
-		// if (command.text.equals(autoClosingPair.getOpen())) {
-		// command.text += autoClosingPair.getClose();
-		// command.caretOffset = command.offset + 1;
-		// command.shiftsCaret = false;
-		// break;
-		// }
-		// }
-		// }
 	}
 
 	/**


### PR DESCRIPTION
In order to simplify the flow when a user is likely to type a character
that was auto-inserted earlier, like a ) after user typed ( while user
was typing (), we just ignore typed auto-close characters if it's
already in the document and we only move the caret.


Signed-off-by: Mickael Istria <mistria@redhat.com>