### PR TITLE
Fix NullPointerException and make getFileTypes return non null values

### DIFF
--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/parser/Raw.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/parser/Raw.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright (c) 2015-2017 Angelo ZERR.
+ *  Copyright (c) 2015-2019 Angelo ZERR.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -8,6 +8,7 @@
  *
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
+ *  Pierre-Yves B. - Issue #221 NullPointerException when retrieving fileTypes
  */
 package org.eclipse.tm4e.core.internal.grammar.parser;
 
@@ -242,12 +243,15 @@ public class Raw extends HashMap<String, Object> implements IRawRepository, IRaw
 	public Collection<String> getFileTypes() {
 		if(fileTypes==null) {
 			List<String> list=new ArrayList<>();
-			for(Object o: (Collection<?>) super.get("fileTypes")) {
-				String str=o.toString();
-				// #202
-				if(str.startsWith("."))
-					str=str.substring(1);
-				list.add(str);
+			Collection<?> unparsedFileTypes = (Collection<?>) super.get("fileTypes");
+			if (unparsedFileTypes != null) {
+				for(Object o: unparsedFileTypes) {
+					String str=o.toString();
+					// #202
+					if(str.startsWith("."))
+						str=str.substring(1);
+					list.add(str);
+				}
 			}
 			fileTypes=list;
 		}

--- a/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/internal/AbstractGrammarRegistryManager.java
+++ b/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/internal/AbstractGrammarRegistryManager.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright (c) 2015-2017 Angelo ZERR.
+ *  Copyright (c) 2015-2019 Angelo ZERR.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -8,6 +8,7 @@
  *
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
+ *  Pierre-Yves B. - Issue #221 NullPointerException when retrieving fileTypes
  */
 package org.eclipse.tm4e.registry.internal;
 
@@ -112,7 +113,7 @@ public abstract class AbstractGrammarRegistryManager extends Registry implements
 			IGrammar grammar = getGrammarForScope(definition.getScopeName());
 			if (grammar != null) {
 				Collection<String> fileTypes = grammar.getFileTypes();
-				if (fileTypes != null && fileTypes.contains(fileType)) {
+				if (fileTypes.contains(fileType)) {
 					return grammar;
 				}
 			}

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/widgets/GrammarInfoWidget.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/widgets/GrammarInfoWidget.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright (c) 2015-2017 Angelo ZERR.
+ *  Copyright (c) 2015-2019 Angelo ZERR.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -8,6 +8,7 @@
  *
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
+ *  Pierre-Yves B. - Issue #221 NullPointerException when retrieving fileTypes
  */
 package org.eclipse.tm4e.ui.internal.widgets;
 
@@ -82,8 +83,7 @@ public class GrammarInfoWidget extends Composite {
 			String scope = grammar.getScopeName();
 			scopeNameText.setText(scope != null ? scope : "");
 			Collection<String> fileTypes = grammar.getFileTypes();
-			String types = fileTypes != null ? fileTypes.stream().map(Object::toString).collect(Collectors.joining(","))
-					: "";
+			String types = fileTypes.stream().map(Object::toString).collect(Collectors.joining(","));
 			fileTypesText.setText(types);
 		}
 	}


### PR DESCRIPTION
Fixes #221. `getFileTypes()` now returns empty list when `super.get("fileTypes")` is `null`, which also allowed to simplify some code by removing null checks from points of call.

Signed-off-by: Pierre-Yves B. <PyvesDev@gmail.com>