### PR TITLE
Mark bundles as lazily activated

### DIFF
--- a/org.eclipse.tm4e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.core/META-INF/MANIFEST.MF
@@ -26,3 +26,4 @@ Export-Package: org.eclipse.tm4e.core,
  org.eclipse.tm4e.core.registry,
  org.eclipse.tm4e.core.theme,
  org.eclipse.tm4e.core.theme.css
+Bundle-ActivationPolicy: lazy

--- a/org.eclipse.tm4e.languageconfiguration.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.languageconfiguration.tests/META-INF/MANIFEST.MF
@@ -17,3 +17,4 @@ Require-Bundle: org.junit;bundle-version="4.12.0",
  org.eclipse.ui.workbench.texteditor,
  org.eclipse.jface.text,
  org.eclipse.ui
+Bundle-ActivationPolicy: lazy

--- a/org.eclipse.tm4e.languageconfiguration/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.languageconfiguration/META-INF/MANIFEST.MF
@@ -23,3 +23,4 @@ Require-Bundle: org.eclipse.jface.text,
  org.eclipse.core.expressions
 Bundle-Activator: org.eclipse.tm4e.languageconfiguration.internal.LanguageConfigurationPlugin
 Export-Package: org.eclipse.tm4e.languageconfiguration
+Bundle-ActivationPolicy: lazy

--- a/org.eclipse.tm4e.registry/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.registry/META-INF/MANIFEST.MF
@@ -12,3 +12,4 @@ Require-Bundle: org.eclipse.tm4e.core,
 Export-Package: org.eclipse.tm4e.registry
 Bundle-Activator: org.eclipse.tm4e.registry.TMEclipseRegistryPlugin
 Bundle-Localization: plugin
+Bundle-ActivationPolicy: lazy

--- a/org.eclipse.tm4e.samples/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.samples/META-INF/MANIFEST.MF
@@ -13,4 +13,5 @@ Require-Bundle: org.eclipse.jface.text,
  org.eclipse.tm4e.ui,
  org.eclipse.ui.genericeditor;bundle-version="1.0.0";resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-ActivationPolicy: lazy
 


### PR DESCRIPTION
Fix #230 by marking bundles as lazily activated

The error is caused by the exception-logging code as `LanguageConfigurationPlugin.getInstance()` returns `null` since the plugin has not been explicitly activated:

https://github.com/eclipse/tm4e/blob/8731eb78c1e4a612cdec5df42c7b407126e2d089/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/LanguageConfigurationDefinition.java#L123-L126

This fix changes all bundles to be lazily activated. 