### PR TITLE
Improve error handling (don't hide exception)

### DIFF
--- a/org.eclipse.tm4e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tm4e.core
-Bundle-Version: 0.4.0.qualifier
+Bundle-Version: 0.4.1.qualifier
 Require-Bundle: org.apache.batik.css;bundle-version="1.9.1";resolution:=optional,
  org.apache.batik.util;bundle-version="1.9.1";resolution:=optional,
  com.google.gson;resolution:=optional,

--- a/org.eclipse.tm4e.core/pom.xml
+++ b/org.eclipse.tm4e.core/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.eclipse.tm4e.core</artifactId>
   <packaging>eclipse-plugin</packaging>
-  <version>0.4.0-SNAPSHOT</version>
+  <version>0.4.1-SNAPSHOT</version>
   <parent>
     <groupId>org.eclipse</groupId>
     <artifactId>org.eclipse.tm4e</artifactId>

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/TMException.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/TMException.java
@@ -22,4 +22,8 @@ public class TMException extends RuntimeException {
 	public TMException(String message) {
 		super(message);
 	}
+
+	public TMException(String message, Throwable cause) {
+		super(message, cause);
+	}
 }

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/registry/Registry.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/registry/Registry.java
@@ -115,7 +115,7 @@ public class Registry {
 					// callback(new Error('Unknown location for grammar <' +
 					// initialScopeName + '>'), null);
 					// return;
-					throw new TMException("Unknown location for grammar <" + initialScopeName + ">");
+					throw new TMException("Unknown location for grammar <" + initialScopeName + ">", e);
 				}
 			}
 		}

--- a/org.eclipse.tm4e.feature/feature.xml
+++ b/org.eclipse.tm4e.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.tm4e.feature"
       label="%featureName"
-      version="0.4.0.qualifier"
+      version="0.4.1.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.tm4e.feature/pom.xml
+++ b/org.eclipse.tm4e.feature/pom.xml
@@ -7,5 +7,5 @@
   </parent>
   <artifactId>org.eclipse.tm4e.feature</artifactId>
   <packaging>eclipse-feature</packaging>
-  <version>0.4.0-SNAPSHOT</version>
+  <version>0.4.1-SNAPSHOT</version>
 </project>


### PR DESCRIPTION
I got the "Unknown location for grammar ..." exception and didn't knew what went wrong because the catched exception was not added to the new exception. 