### PR TITLE
Fixes to avoid NPEs

### DIFF
--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/model/Tokenizer.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/model/Tokenizer.java
@@ -62,7 +62,7 @@ public class Tokenizer implements ITokenizationSupport {
 		// state
 		// );
 		// }
-		TMState freshState = state.clone();
+		TMState freshState = state != null ? state.clone() : getInitialState();
 		ITokenizeLineResult textMateResult = grammar.tokenizeLine(line, freshState.getRuleStack());
 		freshState.setRuleStack(textMateResult.getRuleStack());
 

--- a/org.eclipse.tm4e.languageconfiguration/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.languageconfiguration/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tm4e.languageconfiguration;singleton:=true
-Bundle-Version: 0.3.4.qualifier
+Bundle-Version: 0.3.5.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.jface.text,
  org.eclipse.ui.genericeditor,

--- a/org.eclipse.tm4e.languageconfiguration/pom.xml
+++ b/org.eclipse.tm4e.languageconfiguration/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.eclipse.tm4e.languageconfiguration</artifactId>
   <packaging>eclipse-plugin</packaging>
-  <version>0.3.4-SNAPSHOT</version>
+  <version>0.3.5-SNAPSHOT</version>
   <parent>
     <groupId>org.eclipse</groupId>
     <artifactId>org.eclipse.tm4e</artifactId>

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/LanguageConfigurationCharacterPairMatcher.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/LanguageConfigurationCharacterPairMatcher.java
@@ -109,6 +109,7 @@ public class LanguageConfigurationCharacterPairMatcher
 			// initizalize a DefaultCharacterPairMatcher by using character pairs of the
 			// language configuration.
 			StringBuilder chars = new StringBuilder();
+			this.document = document;
 			IContentType[] contentTypes = findContentTypes(document);
 			if (contentTypes != null) {
 				LanguageConfigurationRegistryManager registry = LanguageConfigurationRegistryManager.getInstance();
@@ -131,8 +132,9 @@ public class LanguageConfigurationCharacterPairMatcher
 	private IContentType[] findContentTypes(IDocument document) {
 		try {
 			ContentTypeInfo info = ContentTypeHelper.findContentTypes(document);
-			this.document = document;
-			return info.getContentTypes();
+			if(info != null) {
+				return info.getContentTypes();
+			}
 		} catch (CoreException e) {
 			e.printStackTrace();
 		}


### PR DESCRIPTION
Two simple fixes for NPEs observed in practice:

  - I periodically encountered situations where the state was null in the Tokenizer with the Go textmate grammars at https://github.com/syscrusher/golang.tmbundle/
  - It's possible for a document to not have a content-type
