### PR TITLE
#246 Use comment block hotkey on mac similar to JDT

### DIFF
--- a/org.eclipse.tm4e.languageconfiguration/plugin.xml
+++ b/org.eclipse.tm4e.languageconfiguration/plugin.xml
@@ -69,7 +69,7 @@
            contextId="org.eclipse.ui.textEditorScope"
            schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
            platform="carbon"
-           sequence="M1+/">
+           sequence="M1+M4+/">
      </key>
      <key
            commandId="org.eclipse.tm4e.languageconfiguration.removeblockcommentcommand"
@@ -82,7 +82,7 @@
            contextId="org.eclipse.ui.textEditorScope"
            schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
            platform="carbon"
-           sequence="M1+\">
+           sequence="M1+M4+\">
      </key>
      <key
            contextId="org.eclipse.ui.textEditorScope"


### PR DESCRIPTION
Changed macOS block comment hotkeys. Now it is more consistent with Eclipse JDT