### PR TITLE
Remove duplicated deps in MANIFEST/pom

### DIFF
--- a/org.eclipse.tm4e.core/pom.xml
+++ b/org.eclipse.tm4e.core/pom.xml
@@ -8,41 +8,4 @@
     <artifactId>org.eclipse.tm4e</artifactId>
     <version>0.3.2-SNAPSHOT</version>
   </parent>
-  
-  <!-- Repeat dependencies as Mvn artifacts to org.eclipse.tm4e.core
-   can be consumed as a Java lib with Mvn (without OSGi not p2).
-   Tycho's pomDependencies must NOT be set to "consider" -->
-  <dependencies>
-		<dependency>
-			<groupId>org.jruby.joni</groupId>
-			<artifactId>joni</artifactId>
-			<version>2.1.11</version>
-		</dependency>
-		<dependency>
-			<groupId>org.jruby.jcodings</groupId>
-			<artifactId>jcodings</artifactId>
-			<version>1.0.18</version>
-		</dependency>
-		<dependency>
-			<groupId>com.google.code.gson</groupId>
-			<artifactId>gson</artifactId>
-			<version>2.8.6</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.xmlgraphics</groupId>
-			<artifactId>batik-css</artifactId>
-			<version>1.14</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.xmlgraphics</groupId>
-			<artifactId>batik-util</artifactId>
-			<version>1.14</version>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-api</artifactId>
-			<version>5.7.1</version>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
 </project>

--- a/org.eclipse.tm4e.languageconfiguration/pom.xml
+++ b/org.eclipse.tm4e.languageconfiguration/pom.xml
@@ -8,16 +8,4 @@
     <artifactId>org.eclipse.tm4e</artifactId>
     <version>0.3.2-SNAPSHOT</version>
   </parent>
-  
-  <!-- Repeat dependencies as Mvn artifacts to org.eclipse.tm4e.core
-   can be consumed as a Java lib with Mvn (without OSGi not p2).
-   Tycho's pomDependencies must NOT be set to "consider" -->
-  <dependencies>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-api</artifactId>
-			<version>5.7.1</version>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
 </project>


### PR DESCRIPTION
Since Tycho 2.4 does configure the test classpath directly with the
dependencies from MANIFEST.MF + JUnit configuration and does run
embedded tests with maven-surefire-plugin, we don't need to duplicate
dependencies any more.
Actually, duplicating dependencies can cause problems because of
signatures not being available on all artifacts.