### PR TITLE
Detect grammars for base content-types

### DIFF
--- a/org.eclipse.tm4e.registry/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.registry/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.tm4e.registry;singleton:=true
-Bundle-Version: 0.4.1.qualifier
+Bundle-Version: 0.5.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.tm4e.core,
  org.eclipse.core.runtime,

--- a/org.eclipse.tm4e.registry/pom.xml
+++ b/org.eclipse.tm4e.registry/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.eclipse.tm4e.registry</artifactId>
   <packaging>eclipse-plugin</packaging>
-  <version>0.4.1-SNAPSHOT</version>
+  <version>0.5.0-SNAPSHOT</version>
   <parent>
     <groupId>org.eclipse</groupId>
     <artifactId>org.eclipse.tm4e</artifactId>

--- a/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/IGrammarRegistryManager.java
+++ b/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/IGrammarRegistryManager.java
@@ -12,6 +12,7 @@
 package org.eclipse.tm4e.registry;
 
 import java.util.Collection;
+import java.util.List;
 
 import org.eclipse.core.runtime.content.IContentType;
 import org.eclipse.tm4e.core.grammar.IGrammar;
@@ -60,13 +61,10 @@ public interface IGrammarRegistryManager {
 	// --------------- TextMate grammar queries methods.
 
 	/**
-	 * Returns the {@link IGrammar} for the given content types and null
-	 * otherwise.
-	 * 
-	 * @param contentTypes
-	 *            the content type.
-	 * @return the {@link IGrammar} for the given content type and null
-	 *         otherwise.
+	 * @param contentTypes the content types to lookup for grammar association.
+	 * @return the first {@link IGrammar} that applies to given content-types, or
+	 * <code>null</code> if no content-type has a grammar associated. Grammars associated
+	 * with parent content-types will be returned if applicable.
 	 */
 	IGrammar getGrammarFor(IContentType[] contentTypes);
 
@@ -96,7 +94,7 @@ public interface IGrammarRegistryManager {
 	 * @return the list of content types bound with the given scope name and
 	 *         null otherwise.
 	 */
-	String[] getContentTypesForScope(String scopeName);
+	List<IContentType> getContentTypesForScope(String scopeName);
 	
 	Collection<String> getInjections(String scopeName);
 }

--- a/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/WorkingCopyGrammarRegistryManager.java
+++ b/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/WorkingCopyGrammarRegistryManager.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import org.eclipse.core.runtime.content.IContentType;
 import org.eclipse.tm4e.registry.internal.AbstractGrammarRegistryManager;
 import org.osgi.service.prefs.BackingStoreException;
 
@@ -42,12 +43,7 @@ public class WorkingCopyGrammarRegistryManager extends AbstractGrammarRegistryMa
 			super.registerGrammarDefinition(definition);
 			// Copy binding scope/content types
 			String scopeName = definition.getScopeName();
-			String[] contentTypes = manager.getContentTypesForScope(scopeName);
-			if (contentTypes != null) {
-				for (String contentTypeId : contentTypes) {
-					super.registerContentTypeBinding(contentTypeId, scopeName);
-				}
-			}
+			manager.getContentTypesForScope(scopeName).forEach(contentType -> super.registerContentTypeBinding(contentType, scopeName));
 			// Copy injection
 			Collection<String> injections = manager.getInjections(scopeName);
 			if (injections != null) {

--- a/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/internal/AbstractGrammarRegistryManager.java
+++ b/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/internal/AbstractGrammarRegistryManager.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 import org.eclipse.core.runtime.content.IContentType;
 import org.eclipse.tm4e.core.grammar.IGrammar;
@@ -77,7 +78,7 @@ public abstract class AbstractGrammarRegistryManager extends Registry implements
 		}
 		// Find grammar by content type
 		for (IContentType contentType : contentTypes) {
-			String scopeName = getScopeNameForContentType(contentType.getId());
+			String scopeName = getScopeNameForContentType(contentType);
 			if (scopeName != null) {
 				IGrammar grammar = getGrammarForScope(scopeName);
 				if (grammar != null) {
@@ -191,22 +192,28 @@ public abstract class AbstractGrammarRegistryManager extends Registry implements
 	}
 
 	/**
-	 * Returns scope name bound with the given content type and null otherwise.
-	 *
-	 * @param contentTypeId
-	 * @return scope name bound with the given content type and null otherwise.
+	 * @param contentType
+	 * @return scope name bound with the given content type (or its base type) and
+	 *         <code>null</code> otherwise.
 	 */
-	public String getScopeNameForContentType(String contentTypeId) {
-		return pluginCache.getScopeNameForContentType(contentTypeId);
+	public String getScopeNameForContentType(IContentType contentType) {
+		while (contentType != null) {
+			String scopeName = pluginCache.getScopeNameForContentType(contentType);
+			if (scopeName != null) {
+				return scopeName;
+			}
+			contentType = contentType.getBaseType();
+		}
+		return null;
 	}
 
 	@Override
-	public String[] getContentTypesForScope(String scopeName) {
+	public List<IContentType> getContentTypesForScope(String scopeName) {
 		return pluginCache.getContentTypesForScope(scopeName);
 	}
 
-	public void registerContentTypeBinding(String contentTypeId, String scopeName) {
-		pluginCache.registerContentTypeBinding(contentTypeId, scopeName);
+	public void registerContentTypeBinding(IContentType contentType, String scopeName) {
+		pluginCache.registerContentTypeBinding(contentType, scopeName);
 	}
 
 	@Override

--- a/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/internal/GrammarCache.java
+++ b/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/internal/GrammarCache.java
@@ -14,9 +14,12 @@ package org.eclipse.tm4e.registry.internal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
+import org.eclipse.core.runtime.content.IContentType;
 import org.eclipse.tm4e.registry.IGrammarDefinition;
 
 /**
@@ -27,7 +30,7 @@ public class GrammarCache {
 
 	private final Map<String /* Scope name */, IGrammarDefinition> definitions;
 	private final Map<String /* Scope name */, Collection<String>> injections;
-	private final Map<String /* IContentType Id */ , String /* Scope name */> scopeNameBindings;
+	private final Map<IContentType , String /* Scope name */> scopeNameBindings;
 
 	public GrammarCache() {
 		this.definitions = new HashMap<>();
@@ -101,23 +104,23 @@ public class GrammarCache {
 	/**
 	 * Returns scope name bound with the given content type and null otherwise.
 	 * 
-	 * @param contentTypeId
+	 * @param contentType	
 	 * @return scope name bound with the given content type and null otherwise.
 	 */
-	public String getScopeNameForContentType(String contentTypeId) {
-		return scopeNameBindings.get(contentTypeId);
+	public String getScopeNameForContentType(IContentType contentType) {
+		return scopeNameBindings.get(contentType);
 	}
 
-	public String[] getContentTypesForScope(String scopeName) {
+	public List<IContentType> getContentTypesForScope(String scopeName) {
 		if (scopeName == null) {
-			return null;
+			return List.of();
 		}
 		return scopeNameBindings.entrySet().stream().filter(map -> scopeName.equals(map.getValue()))
-				.map(map -> map.getKey()).collect(Collectors.toList()).toArray(new String[0]);
+				.map(Entry::getKey).collect(Collectors.toList());
 	}
 
-	public void registerContentTypeBinding(String contentTypeId, String scopeName) {
-		scopeNameBindings.put(contentTypeId, scopeName);
+	public void registerContentTypeBinding(IContentType contentType, String scopeName) {
+		scopeNameBindings.put(contentType, scopeName);
 	}
 
 }

--- a/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/internal/GrammarRegistryManager.java
+++ b/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/internal/GrammarRegistryManager.java
@@ -13,6 +13,7 @@ package org.eclipse.tm4e.registry.internal;
 
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.content.IContentType;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.tm4e.registry.GrammarDefinition;
@@ -73,8 +74,13 @@ public class GrammarRegistryManager extends AbstractGrammarRegistryManager {
 				super.registerInjection(scopeName, injectTo);
 			} else if (XMLConstants.SCOPE_NAME_CONTENT_TYPE_BINDING_ELT.equals(extensionName)) {
 				String contentTypeId = ce.getAttribute(XMLConstants.CONTENT_TYPE_ID_ATTR);
-				String scopeName = ce.getAttribute(XMLConstants.SCOPE_NAME_ATTR);
-				super.registerContentTypeBinding(contentTypeId, scopeName);
+				IContentType contentType = Platform.getContentTypeManager().getContentType(contentTypeId);
+				if (contentType == null) {
+					Platform.getLog(getClass()).warn("No content-type found with id='" + contentTypeId + "', ignoring TM4E association.");
+				} else {
+					String scopeName = ce.getAttribute(XMLConstants.SCOPE_NAME_ATTR);
+					super.registerContentTypeBinding(contentType, scopeName);
+				}
 			}
 		}
 	}

--- a/org.eclipse.tm4e.ui.tests/plugin.xml
+++ b/org.eclipse.tm4e.ui.tests/plugin.xml
@@ -20,6 +20,13 @@
             name="Test Content Type for TM4E (typescipt)"
             priority="normal">
       </content-type>
+      <content-type
+            base-type="org.eclipse.tm4e.ui.tests.testContentType"
+            file-names="child.ts"
+            id="org.eclipse.tm4e.ui.tests.testContentType.child"
+            name="Child of test content-type"
+            priority="normal">
+      </content-type>
    </extension>
    <extension
          point="org.eclipse.ui.genericeditor.presentationReconcilers">

--- a/org.eclipse.tm4e.ui.tests/src/test/java/org/eclipse/tm4e/ui/RegistryTest.java
+++ b/org.eclipse.tm4e.ui.tests/src/test/java/org/eclipse/tm4e/ui/RegistryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015-2017 Angelo ZERR.
+ * Copyright (c) 2015-2021 Angelo ZERR.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -23,6 +23,13 @@ public class RegistryTest {
 	@Test
 	public void testGrammarRegistered() {
 		IContentType contentType = Platform.getContentTypeManager().getContentType("org.eclipse.tm4e.ui.tests.testContentType");
+		IGrammar grammar = TMEclipseRegistryPlugin.getGrammarRegistryManager().getGrammarFor(new IContentType[] { contentType });
+		Assertions.assertNotNull(grammar);
+	}
+
+	@Test
+	public void testThemeAppliesToSubtypes() {
+		IContentType contentType = Platform.getContentTypeManager().getContentType("org.eclipse.tm4e.ui.tests.testContentType.child");
 		IGrammar grammar = TMEclipseRegistryPlugin.getGrammarRegistryManager().getGrammarFor(new IContentType[] { contentType });
 		Assertions.assertNotNull(grammar);
 	}

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/preferences/GrammarPreferencePage.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/preferences/GrammarPreferencePage.java
@@ -267,8 +267,7 @@ public class GrammarPreferencePage extends PreferencePage implements IWorkbenchP
 
 			private void fillContentTypeTab(String scopeName) {
 				// Load the content type binding for the given grammar
-				String[] contentTypes = grammarRegistryManager.getContentTypesForScope(scopeName);
-				contentTypesWidget.setInput(contentTypes);
+				contentTypesWidget.setInput(grammarRegistryManager.getContentTypesForScope(scopeName));
 			}
 
 			private IThemeAssociation fillThemeTab(IGrammarDefinition definition) {

--- a/target-platform/tm4e-target.target
+++ b/target-platform/tm4e-target.target
@@ -7,7 +7,7 @@
 <repository location="https://download.eclipse.org/cbi/updates/license/2.0.2.v20181016-2210/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="com.google.gson" version="2.8.7.v20210624-1215"/>
+<unit id="com.google.gson" version="2.8.8.v20211029-0838"/>
 <unit id="org.jcodings" version="1.0.18.v20170306-1742"/>
 <unit id="org.joni" version="2.1.11.v20170306-1742"/>
 <unit id="org.apache.batik.css" version="1.14.0.v20210324-0332"/>


### PR DESCRIPTION
This prevent from having to duplicate grammar associations for all
children types