### PR TITLE
Fix ClassCastException: ContentTypeHandler cannot be cast to String

### DIFF
--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/widgets/ContentTypeLabelProvider.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/widgets/ContentTypeLabelProvider.java
@@ -34,12 +34,19 @@ public class ContentTypeLabelProvider extends LabelProvider implements ITableLab
 
 	@Override
 	public String getColumnText(Object element, int columnIndex) {
-		String contentTypeId = (String) element;
 		switch (columnIndex) {
 		case 0:
-			IContentType contentType = Platform.getContentTypeManager().getContentType(contentTypeId);
-			if (contentType == null) {
-				return contentTypeId;
+			IContentType contentType = null;
+			if(element instanceof IContentType) {
+				contentType = (IContentType) element;
+			} else if(element instanceof String) {
+				String contentTypeId = (String) element;
+				contentType = Platform.getContentTypeManager().getContentType(contentTypeId);
+				if (contentType == null) {
+					return contentTypeId;
+				}
+			} else {
+				return ""; //$NON-NLS-1$
 			}
 			return contentType.getName() + " (" + contentType.getId() + ")";
 		default:


### PR DESCRIPTION
This fixes the exception
```python
java.lang.ClassCastException: class org.eclipse.core.internal.content.ContentTypeHandler cannot be cast to class java.lang.String (org.eclipse.core.internal.content.ContentTypeHandler is in unnamed module of loader org.eclipse.osgi.internal.loader.EquinoxClassLoader @4d02f0b2; java.lang.String is in module java.base of loader 'bootstrap')
	at org.eclipse.tm4e.ui.internal.widgets.ContentTypeLabelProvider.getColumnText(ContentTypeLabelProvider.java:37)
	at org.eclipse.jface.viewers.TableColumnViewerLabelProvider.update(TableColumnViewerLabelProvider.java:69)
	at org.eclipse.jface.viewers.ViewerColumn.refresh(ViewerColumn.java:144)
	at org.eclipse.jface.viewers.AbstractTableViewer.doUpdateItem(AbstractTableViewer.java:396)
	at org.eclipse.jface.viewers.StructuredViewer$UpdateItemSafeRunnable.run(StructuredViewer.java:427)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:45)
	at org.eclipse.jface.util.SafeRunnable.run(SafeRunnable.java:174)
	at org.eclipse.jface.viewers.StructuredViewer.updateItem(StructuredViewer.java:2109)
	at org.eclipse.jface.viewers.AbstractTableViewer.createItem(AbstractTableViewer.java:288)
	at org.eclipse.jface.viewers.AbstractTableViewer.internalRefreshAll(AbstractTableViewer.java:726)
	at org.eclipse.jface.viewers.AbstractTableViewer.internalRefresh(AbstractTableViewer.java:618)
	at org.eclipse.jface.viewers.AbstractTableViewer.internalRefresh(AbstractTableViewer.java:610)
	at org.eclipse.jface.viewers.AbstractTableViewer.lambda$0(AbstractTableViewer.java:572)
	at org.eclipse.jface.viewers.StructuredViewer.preservingSelection(StructuredViewer.java:1398)
	at org.eclipse.jface.viewers.StructuredViewer.preservingSelection(StructuredViewer.java:1359)
	at org.eclipse.jface.viewers.AbstractTableViewer.inputChanged(AbstractTableViewer.java:572)
	at org.eclipse.jface.viewers.ContentViewer.setInput(ContentViewer.java:282)
	at org.eclipse.jface.viewers.StructuredViewer.setInput(StructuredViewer.java:1632)
	at org.eclipse.tm4e.ui.internal.widgets.TableAndButtonsWidget.setInput(TableAndButtonsWidget.java:97)
	at org.eclipse.tm4e.ui.internal.preferences.GrammarPreferencePage$1.fillContentTypeTab(GrammarPreferencePage.java:270)
	at org.eclipse.tm4e.ui.internal.preferences.GrammarPreferencePage$1.selectGrammar(GrammarPreferencePage.java:256)
	at org.eclipse.tm4e.ui.internal.preferences.GrammarPreferencePage$1.selectionChanged(GrammarPreferencePage.java:248)
	at org.eclipse.jface.viewers.Viewer$1.run(Viewer.java:151)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:45)
	at org.eclipse.jface.util.SafeRunnable.run(SafeRunnable.java:174)
	at org.eclipse.jface.viewers.Viewer.fireSelectionChanged(Viewer.java:148)
	at org.eclipse.jface.viewers.StructuredViewer.updateSelection(StructuredViewer.java:2130)
	at org.eclipse.jface.viewers.StructuredViewer.handleSelect(StructuredViewer.java:1176)
	at org.eclipse.jface.viewers.StructuredViewer$4.widgetSelected(StructuredViewer.java:1205)
	at org.eclipse.jface.util.OpenStrategy.fireSelectionEvent(OpenStrategy.java:242)
	at org.eclipse.jface.util.OpenStrategy$1.handleEvent(OpenStrategy.java:400)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:89)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:4237)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1060)
	at org.eclipse.swt.widgets.Display.runDeferredEvents(Display.java:4054)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3626)
	at org.eclipse.jface.window.Window.runEventLoop(Window.java:823)
	at org.eclipse.jface.window.Window.open(Window.java:799)
	at org.eclipse.ui.internal.OpenPreferencesAction.run(OpenPreferencesAction.java:66)
	at org.eclipse.jface.action.Action.runWithEvent(Action.java:474)
	at org.eclipse.jface.action.ActionContributionItem.handleWidgetSelection(ActionContributionItem.java:580)
	at org.eclipse.jface.action.ActionContributionItem.lambda$4(ActionContributionItem.java:414)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:89)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:4237)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1060)
	at org.eclipse.swt.widgets.Display.runDeferredEvents(Display.java:4054)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3626)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$5.run(PartRenderingEngine.java:1150)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:338)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1041)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:155)
	at org.eclipse.ui.internal.Workbench.lambda$3(Workbench.java:644)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:338)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:551)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:156)
	at org.haxe4e.studio.HaxeStudioApplication.start(HaxeStudioApplication.java:55)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:203)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:136)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:401)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:255)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:659)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:596)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1467)
```

That occurs in the grammar dialog.

![image](https://user-images.githubusercontent.com/426959/144710904-e1d214f9-339d-4aae-b713-ec0a9f8493d6.png)
