### PR TITLE
minor code cleanup

### DIFF
--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/css/RGBColorImpl.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/css/RGBColorImpl.java
@@ -18,9 +18,9 @@ import org.w3c.dom.css.RGBColor;
 
 public class RGBColorImpl extends CSSValueImpl implements RGBColor {
 
-	private CSSPrimitiveValue red;
-	private CSSPrimitiveValue green;
-	private CSSPrimitiveValue blue;
+	private final CSSPrimitiveValue red;
+	private final CSSPrimitiveValue green;
+	private final CSSPrimitiveValue blue;
 
 	public RGBColorImpl(LexicalUnit lexicalUnit) {
 		LexicalUnit nextUnit = lexicalUnit.getParameters();

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/LineTokenizer.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/LineTokenizer.java
@@ -391,7 +391,7 @@ class LineTokenizer {
 		}
 
 		int len = Math.min(captures.size(), captureIndices.length);
-		List<LocalStackElement> localStack = new ArrayList<LocalStackElement>();
+		List<LocalStackElement> localStack = new ArrayList<>();
 		int maxEnd = captureIndices[0].getEnd();
 		IOnigCaptureIndex captureIndex;
 

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/LineTokenizer.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/LineTokenizer.java
@@ -39,7 +39,7 @@ class LineTokenizer {
 
 	private static final Logger LOGGER = Logger.getLogger(LineTokenizer.class.getName());
 
-	class WhileStack {
+	static class WhileStack {
 
 		public final StackElement stack;
 		public final BeginWhileRule rule;
@@ -50,7 +50,7 @@ class LineTokenizer {
 		}
 	}
 
-	class WhileCheckResult {
+	static class WhileCheckResult {
 
 		public final StackElement stack;
 		public final int linePos;

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/LineTokens.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/LineTokens.java
@@ -36,7 +36,7 @@ class LineTokens {
 	private final List<IToken> tokens;
 
 
-	private boolean emitBinaryTokens;
+	private final boolean emitBinaryTokens;
 
 	/**
 	 * used only if `_emitBinaryTokens` is true.

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/Token.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/Token.java
@@ -24,9 +24,9 @@ class Token implements IToken {
 
 	private int startIndex;
 
-	private int endIndex;
+	private final int endIndex;
 
-	private List<String> scopes;
+	private final List<String> scopes;
 
 	public Token(int startIndex, int endIndex, List<String> scopes) {
 		this.startIndex = startIndex;

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/reader/GrammarReader.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/reader/GrammarReader.java
@@ -37,7 +37,7 @@ public class GrammarReader {
 
 	public static final IGrammarParser XML_PARSER = new IGrammarParser() {
 
-		private XMLPListParser<IRawGrammar> parser = new XMLPListParser<>(false);
+		private final XMLPListParser<IRawGrammar> parser = new XMLPListParser<>(false);
 
 		@Override
 		public IRawGrammar parse(InputStream contents) throws Exception {
@@ -47,7 +47,7 @@ public class GrammarReader {
 
 	public static final IGrammarParser JSON_PARSER = new IGrammarParser() {
 
-		private JSONPListParser<IRawGrammar> parser = new JSONPListParser<>(false);
+		private final JSONPListParser<IRawGrammar> parser = new JSONPListParser<>(false);
 
 		@Override
 		public IRawGrammar parse(InputStream contents) throws Exception {

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/reader/SyncGrammarReader.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/reader/SyncGrammarReader.java
@@ -22,8 +22,8 @@ import org.eclipse.tm4e.core.internal.types.IRawGrammar;
 
 public class SyncGrammarReader {
 
-	private InputStream in;
-	private IGrammarParser parser;
+	private final InputStream in;
+	private final IGrammarParser parser;
 
 	SyncGrammarReader(InputStream in, IGrammarParser parser) {
 		this.in = in;

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/matcher/IMatchesName.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/matcher/IMatchesName.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public interface IMatchesName<T> {
 
-	public static final IMatchesName<List<String>> NAME_MATCHER = new IMatchesName<List<String>>() {
+	IMatchesName<List<String>> NAME_MATCHER = new IMatchesName<List<String>>() {
 
 		@Override
 		public boolean match(Collection<String> identifers, List<String> scopes) {

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/matcher/IMatchesName.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/matcher/IMatchesName.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public interface IMatchesName<T> {
 
-	IMatchesName<List<String>> NAME_MATCHER = new IMatchesName<List<String>>() {
+	IMatchesName<List<String>> NAME_MATCHER = new IMatchesName<>() {
 
 		@Override
 		public boolean match(Collection<String> identifers, List<String> scopes) {

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/matcher/Matcher.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/matcher/Matcher.java
@@ -37,7 +37,7 @@ public class Matcher<T> implements Predicate<T> {
 	}
 
 	private static <T> Collection<MatcherWithPriority<T>> createMatchers(String selector, IMatchesName<T> matchesName) {
-		return new Matcher<T>(selector, matchesName).results;
+		return new Matcher<>(selector, matchesName).results;
 	}
 
 	private final List<MatcherWithPriority<T>> results;
@@ -68,7 +68,7 @@ public class Matcher<T> implements Predicate<T> {
 			}
 			Predicate<T> matcher = parseConjunction();
 			if (matcher != null) {
-				results.add(new MatcherWithPriority<T>(matcher, priority));
+				results.add(new MatcherWithPriority<>(matcher, priority));
 			}
 			if (!",".equals(token)) {
 				break;

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/matcher/Matcher.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/matcher/Matcher.java
@@ -164,7 +164,7 @@ public class Matcher<T> implements Predicate<T> {
 
 		private static final Pattern REGEXP = Pattern.compile("([LR]:|[\\w\\.:]+|[\\,\\|\\-\\(\\)])");
 
-		private java.util.regex.Matcher regex;
+		private final java.util.regex.Matcher regex;
 
 		public Tokenizer(String input) {
 			this.regex = REGEXP.matcher(input);

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/oniguruma/OnigRegExp.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/oniguruma/OnigRegExp.java
@@ -39,7 +39,7 @@ public class OnigRegExp {
 	private OnigString lastSearchString;
 	private int lastSearchPosition;
 	private OnigResult lastSearchResult;
-	private Regex regex;
+	private final Regex regex;
 
 	public OnigRegExp(String source) {
 		lastSearchString = null;

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/parser/json/JSONPListParser.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/parser/json/JSONPListParser.java
@@ -29,7 +29,7 @@ public class JSONPListParser<T> {
 	}
 
 	public T parse(InputStream contents) throws Exception {
-		PList<T> pList = new PList<T>(theme);
+		PList<T> pList = new PList<>(theme);
 		JsonReader reader = new JsonReader(new InputStreamReader(contents, StandardCharsets.UTF_8));
 		// reader.setLenient(true);
 		boolean parsing = true;

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/rule/BeginEndRule.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/rule/BeginEndRule.java
@@ -22,9 +22,9 @@ import org.eclipse.tm4e.core.internal.oniguruma.IOnigCaptureIndex;
 
 public class BeginEndRule extends Rule {
 
-	private RegExpSource begin;
+	private final RegExpSource begin;
 	public List<CaptureRule> beginCaptures;
-	private RegExpSource end;
+	private final RegExpSource end;
 	public boolean endHasBackReferences;
 	public List<CaptureRule> endCaptures;
 	public boolean applyEndPatternLast;

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/rule/BeginWhileRule.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/rule/BeginWhileRule.java
@@ -22,10 +22,10 @@ import org.eclipse.tm4e.core.internal.oniguruma.IOnigCaptureIndex;
 
 public class BeginWhileRule extends Rule {
 
-	private RegExpSource begin;
+	private final RegExpSource begin;
 	public final List<CaptureRule> beginCaptures;
 	public final List<CaptureRule> whileCaptures;
-	private RegExpSource _while;
+	private final RegExpSource _while;
 	public final boolean whileHasBackReferences;
 	public final boolean hasMissingPatterns;
 	public final Integer[] patterns;

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/rule/MatchRule.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/rule/MatchRule.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 public class MatchRule extends Rule {
 
-	private RegExpSource match;
+	private final RegExpSource match;
 	public final List<CaptureRule> captures;
 	private RegExpSourceList cachedCompiledPatterns;
 

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/rule/RegExpSource.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/rule/RegExpSource.java
@@ -36,9 +36,9 @@ public class RegExpSource {
 	private static final Pattern REGEXP_CHARACTERS = Pattern
 			.compile("[\\-\\\\\\{\\}\\*\\+\\?\\|\\^\\$\\.\\,\\[\\]\\(\\)\\#\\s]");
 
-	private int ruleId;
+	private final int ruleId;
 	private boolean _hasAnchor;
-	private boolean _hasBackReferences;
+	private final boolean _hasBackReferences;
 	private IRegExpSourceAnchorCache anchorCache;
 	private String source;
 

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/rule/RegExpSource.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/rule/RegExpSource.java
@@ -130,7 +130,7 @@ public class RegExpSource {
 		StringBuffer sb = new StringBuffer();
 		while (m.find()) {
 			String g1 = m.group();
-			int index = Integer.parseInt(g1.substring(1, g1.length()));
+			int index = Integer.parseInt(g1.substring(1));
 			String replacement = escapeRegExpCharacters(capturedValues.size() > index ? capturedValues.get(index) : "");
 			m.appendReplacement(sb, replacement);
 		}

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/rule/RegExpSourceList.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/rule/RegExpSourceList.java
@@ -44,7 +44,7 @@ public class RegExpSourceList {
 	private final RegExpSourceListAnchorCache _anchorCache;
 
 	public RegExpSourceList() {
-		this._items = new ArrayList<RegExpSource>();
+		this._items = new ArrayList<>();
 		this._hasAnchors = false;
 		this._cached = null;
 		this._anchorCache = new RegExpSourceListAnchorCache();
@@ -80,7 +80,7 @@ public class RegExpSourceList {
 	public ICompiledRule compile(IRuleRegistry grammar, boolean allowA, boolean allowG) {
 		if (!this._hasAnchors) {
 			if (this._cached == null) {
-				List<String> regexps = new ArrayList<String>();
+				List<String> regexps = new ArrayList<>();
 				for (RegExpSource regExpSource : _items) {
 					regexps.add(regExpSource.getSource());
 				}
@@ -122,7 +122,7 @@ public class RegExpSourceList {
 	}
 
 	private ICompiledRule _resolveAnchors(boolean allowA, boolean allowG) {
-		List<String> regexps = new ArrayList<String>();
+		List<String> regexps = new ArrayList<>();
 		for (RegExpSource regExpSource : _items) {
 			regexps.add(regExpSource.resolveAnchors(allowA, allowG));
 		}
@@ -134,7 +134,7 @@ public class RegExpSourceList {
 	}
 
 	private Integer[] getRules() {
-		Collection<Integer> ruleIds = new ArrayList<Integer>();
+		Collection<Integer> ruleIds = new ArrayList<>();
 		for (RegExpSource item : this._items) {
 			ruleIds.add(item.getRuleId());
 		}

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/rule/RegExpSourceList.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/rule/RegExpSourceList.java
@@ -29,7 +29,7 @@ import org.eclipse.tm4e.core.internal.oniguruma.OnigScanner;
  */
 public class RegExpSourceList {
 
-	private class RegExpSourceListAnchorCache {
+	private static class RegExpSourceListAnchorCache {
 
 		public ICompiledRule A0_G0;
 		public ICompiledRule A0_G1;

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/rule/RegExpSourceList.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/rule/RegExpSourceList.java
@@ -38,7 +38,7 @@ public class RegExpSourceList {
 
 	}
 
-	private List<RegExpSource> _items;
+	private final List<RegExpSource> _items;
 	private boolean _hasAnchors;
 	private ICompiledRule _cached;
 	private final RegExpSourceListAnchorCache _anchorCache;

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/rule/Rule.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/rule/Rule.java
@@ -23,11 +23,11 @@ public abstract class Rule {
 
 	public final int id;
 
-	private boolean nameIsCapturing;
-	private String name;
+	private final boolean nameIsCapturing;
+	private final String name;
 
-	private boolean contentNameIsCapturing;
-	private String contentName;
+	private final boolean contentNameIsCapturing;
+	private final String contentName;
 
 	public Rule(int id, String name, String contentName) {
 		this.id = id;

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/rule/RuleFactory.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/rule/RuleFactory.java
@@ -139,7 +139,7 @@ public class RuleFactory {
 
 	private static ICompilePatternsResult _compilePatterns(Collection<IRawRule> patterns, IRuleFactoryHelper helper,
 			IRawRepository repository) {
-		Collection<Integer> r = new ArrayList<Integer>();
+		Collection<Integer> r = new ArrayList<>();
 		int patternId;
 		IRawGrammar externalGrammar;
 		Rule rule;

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/utils/RegexSource.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/utils/RegexSource.java
@@ -59,7 +59,7 @@ public class RegexSource {
 			index = Integer.parseInt(match.substring(2, doublePointIndex));
 			command = match.substring(doublePointIndex + 2, match.length() - 1);
 		} else {
-			index = Integer.parseInt(match.substring(1, match.length()));
+			index = Integer.parseInt(match.substring(1));
 		}
 		IOnigCaptureIndex capture = captureIndices.length > index ? captureIndices[index] : null;
 		if (capture != null) {

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/model/TMModel.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/model/TMModel.java
@@ -44,7 +44,7 @@ public class TMModel implements ITMModel {
 	private TokenizerThread fThread;
 
 	private final IModelLines lines;
-	private PriorityBlockingQueue<Integer> invalidLines = new PriorityBlockingQueue<>();
+	private final PriorityBlockingQueue<Integer> invalidLines = new PriorityBlockingQueue<>();
 
 	public TMModel(IModelLines lines) {
 		this.listeners = new ArrayList<>();
@@ -64,7 +64,7 @@ public class TMModel implements ITMModel {
 	 *
 	 */
 	static class TokenizerThread extends Thread {
-		private TMModel model;
+		private final TMModel model;
 		private TMState lastState;
 
 		/**

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/model/TMModel.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/model/TMModel.java
@@ -92,7 +92,7 @@ public class TMModel implements ITMModel {
 					Integer toProcess = model.invalidLines.take();
 					if (model.lines.get(toProcess).isInvalid) {
 						try {
-							this.revalidateTokensNow(toProcess.intValue(), null);
+							this.revalidateTokensNow(toProcess, null);
 						} catch (Exception t) {
 							LOGGER.severe(t.getMessage());
 							if (toProcess < model.lines.getNumberOfLines()) {

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/model/TMState.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/model/TMState.java
@@ -22,7 +22,7 @@ import org.eclipse.tm4e.core.grammar.StackElement;
 
 public class TMState {
 
-	private TMState parentEmbedderState;
+	private final TMState parentEmbedderState;
 	private StackElement ruleStack;
 
 	public TMState(TMState parentEmbedderState, StackElement ruleStatck) {

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/registry/IRegistryOptions.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/registry/IRegistryOptions.java
@@ -24,7 +24,7 @@ import org.eclipse.tm4e.core.theme.IRawTheme;
 
 public interface IRegistryOptions {
 
-	public static final IRegistryOptions DEFAULT_LOCATOR = new IRegistryOptions() {
+	IRegistryOptions DEFAULT_LOCATOR = new IRegistryOptions() {
 
 		@Override
 		public String getFilePath(String scopeName) {

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/theme/css/ISACParserFactory.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/theme/css/ISACParserFactory.java
@@ -23,7 +23,7 @@ public interface ISACParserFactory {
 	 * this method search teh SAC Parser class name to instanciate into System
 	 * property with key org.w3c.css.sac.parser.
 	 */
-	public Parser makeParser() throws ClassNotFoundException,
+	Parser makeParser() throws ClassNotFoundException,
 			IllegalAccessException, InstantiationException,
 			NullPointerException, ClassCastException;
 
@@ -39,7 +39,7 @@ public interface ISACParserFactory {
 	 * @throws NullPointerException
 	 * @throws ClassCastException
 	 */
-	public abstract Parser makeParser(String name)
+	Parser makeParser(String name)
 			throws ClassNotFoundException, IllegalAccessException,
 			InstantiationException, NullPointerException, ClassCastException;
 }

--- a/org.eclipse.tm4e.core/src/test/java/org/eclipse/tm4e/core/grammar/MarkDown.java
+++ b/org.eclipse.tm4e.core/src/test/java/org/eclipse/tm4e/core/grammar/MarkDown.java
@@ -27,19 +27,13 @@ public class MarkDown {
 		IGrammar grammar = registry.loadGrammarFromPathSync(path, Data.class.getResourceAsStream(path));
 		
 		List<String> lines = new ArrayList<>();
-		BufferedReader reader = null;
-		try {
-			reader = new BufferedReader(new InputStreamReader(Data.class.getResourceAsStream("test.md.txt")));
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(Data.class.getResourceAsStream("test.md.txt")))) {
 			String line = null;
 			while ((line = reader.readLine()) != null) {
 				lines.add(line);
 			}
 		} catch (Exception e) {
 			e.printStackTrace();
-		} finally {
-			if (reader != null) {
-				reader.close();
-			}
 		}
 
 		

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/ILanguageConfiguration.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/ILanguageConfiguration.java
@@ -36,7 +36,7 @@ public interface ILanguageConfiguration {
 	 * @return the language's brackets. This configuration implicitly affects
 	 *         pressing Enter around these brackets.
 	 */
-	public List<CharacterPair> getBrackets();
+	List<CharacterPair> getBrackets();
 
 	/**
 	 * Returns the language's auto closing pairs. The 'close' character is
@@ -47,14 +47,14 @@ public interface ILanguageConfiguration {
 	 *         autautomatically inserted with the 'open' character is typed. If not
 	 *         set, the configured brackets will be used.
 	 */
-	public List<AutoClosingPairConditional> getAutoClosingPairs();
+	List<AutoClosingPairConditional> getAutoClosingPairs();
 
 	/**
 	 * Returns the language's rules to be evaluated when pressing Enter.
 	 *
 	 * @return the language's rules to be evaluated when pressing Enter.
 	 */
-	public List<OnEnterRule> getOnEnterRules();
+	List<OnEnterRule> getOnEnterRules();
 
 	/**
 	 * Returns the language's surrounding pairs. When the 'open' character is typed
@@ -66,7 +66,7 @@ public interface ILanguageConfiguration {
 	 *         close characters. If not set, the autoclosing pairs settings will be
 	 *         used.
 	 */
-	public List<CharacterPair> getSurroundingPairs();
+	List<CharacterPair> getSurroundingPairs();
 
 	/**
 	 * Returns the language's folding rules.

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/ToggleLineCommentHandler.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/ToggleLineCommentHandler.java
@@ -219,7 +219,7 @@ public class ToggleLineCommentHandler extends AbstractHandler {
 		int endLineNumber = selection.getEndLine();
 		String oldText = document.get();
 		int deletedChars = 0;
-		Boolean isStartBeforeComment = false;
+		boolean isStartBeforeComment = false;
 
 		while (lineNumber <= endLineNumber) {
 			int commentOffset = oldText.indexOf(comment, document.getLineOffset(lineNumber) + deletedChars);

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/LanguageConfigurationDefinition.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/LanguageConfigurationDefinition.java
@@ -34,7 +34,7 @@ import org.eclipse.tm4e.ui.utils.ContentTypeHelper;
  */
 public class LanguageConfigurationDefinition extends TMResource implements ILanguageConfigurationDefinition {
 
-	private IContentType contentType;
+	private final IContentType contentType;
 	private boolean onEnterEnabled = true;
 	private boolean bracketAutoClosingEnabled = true;
 	private boolean matchingPairsEnabled = true;

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/preferences/LanguageConfigurationPreferencePage.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/preferences/LanguageConfigurationPreferencePage.java
@@ -63,7 +63,7 @@ public class LanguageConfigurationPreferencePage extends PreferencePage implemen
 
 	public final static String PAGE_ID = "org.eclipse.tm4e.languageconfiguration.preferences.LanguageConfigurationPreferencePage"; //$NON-NLS-1$
 
-	private ILanguageConfigurationRegistryManager manager;
+	private final ILanguageConfigurationRegistryManager manager;
 
 	private TableViewer definitionViewer;
 

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/supports/AutoClosingPairConditional.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/supports/AutoClosingPairConditional.java
@@ -16,7 +16,7 @@ import java.util.List;
 @SuppressWarnings("serial")
 public class AutoClosingPairConditional extends CharacterPair {
 
-	private List<String> notIn;
+	private final List<String> notIn;
 
 	public AutoClosingPairConditional(String open, String close, List<String> notIn) {
 		super(open, close);

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/supports/CharacterPairSupport.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/supports/CharacterPairSupport.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 public class CharacterPairSupport {
 
 	private List<CharacterPair> autoClosingPairs;
-	private List<CharacterPair> surroundingPairs;
+	private final List<CharacterPair> surroundingPairs;
 
 	public CharacterPairSupport(List<CharacterPair> brackets, List<AutoClosingPairConditional> autoClosingPairs,
 			List<CharacterPair> surroundingPairs) {

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/supports/CommentSupport.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/supports/CommentSupport.java
@@ -16,7 +16,7 @@ import org.eclipse.jface.text.IDocument;
 
 public class CommentSupport {
 
-	private Comments comments;
+	private final Comments comments;
 
 	public CommentSupport(Comments comments) {
 		this.comments = comments;

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/supports/OnEnterSupport.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/supports/OnEnterSupport.java
@@ -35,9 +35,7 @@ public class OnEnterSupport {
 
 	public OnEnterSupport(List<CharacterPair> brackets, List<OnEnterRule> regExpRules) {
 		this.brackets = (brackets != null ? brackets : DEFAULT_BRACKETS).stream().filter(el -> el != null)
-				.map((bracket -> {
-					return new ProcessedBracketPair(bracket.getKey(), bracket.getValue());
-				})).collect(Collectors.toList());
+				.map((bracket -> new ProcessedBracketPair(bracket.getKey(), bracket.getValue()))).collect(Collectors.toList());
 
 		this.regExpRules = regExpRules != null ? regExpRules : Collections.emptyList();
 	}

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/widgets/CharacterPairsTableWidget.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/widgets/CharacterPairsTableWidget.java
@@ -56,7 +56,7 @@ public class CharacterPairsTableWidget extends TableViewer {
 		return gc.stringExtent(string).x + 10;
 	}
 
-	protected class CharacterPairContentProvider implements IStructuredContentProvider {
+	protected static class CharacterPairContentProvider implements IStructuredContentProvider {
 
 		private List<CharacterPair> characterPairList;
 
@@ -81,7 +81,7 @@ public class CharacterPairsTableWidget extends TableViewer {
 		}
 	}
 
-	protected class CharacterPairLabelProvider extends LabelProvider implements ITableLabelProvider {
+	protected static class CharacterPairLabelProvider extends LabelProvider implements ITableLabelProvider {
 
 		@Override
 		public Image getColumnImage(Object element, int columnIndex) {

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/widgets/OnEnterRuleTableWidget.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/widgets/OnEnterRuleTableWidget.java
@@ -72,7 +72,7 @@ public class OnEnterRuleTableWidget extends TableViewer {
 		return gc.stringExtent(string).x + 10;
 	}
 
-	protected class OnEnterRuleContentProvider implements IStructuredContentProvider {
+	protected static class OnEnterRuleContentProvider implements IStructuredContentProvider {
 
 		private List<OnEnterRule> onEnterRulesList;
 
@@ -97,7 +97,7 @@ public class OnEnterRuleTableWidget extends TableViewer {
 		}
 	}
 
-	protected class OnEnterRuleLabelProvider extends LabelProvider implements ITableLabelProvider {
+	protected static class OnEnterRuleLabelProvider extends LabelProvider implements ITableLabelProvider {
 
 		@Override
 		public Image getColumnImage(Object element, int columnIndex) {

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/wizards/SelectLanguageConfigurationWizardPage.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/wizards/SelectLanguageConfigurationWizardPage.java
@@ -208,7 +208,7 @@ public class SelectLanguageConfigurationWizardPage extends WizardPage implements
 				.setText(((IContentType) event.getStructuredSelection().getFirstElement()).toString()));
 	}
 
-	private class ContentTypesLabelProvider extends LabelProvider {
+	private static class ContentTypesLabelProvider extends LabelProvider {
 		@Override
 		public String getText(Object element) {
 			IContentType contentType = (IContentType) element;
@@ -216,7 +216,7 @@ public class SelectLanguageConfigurationWizardPage extends WizardPage implements
 		}
 	}
 
-	private class ContentTypesContentProvider implements ITreeContentProvider {
+	private static class ContentTypesContentProvider implements ITreeContentProvider {
 
 		private IContentTypeManager manager = Platform.getContentTypeManager();
 

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/wizards/SelectLanguageConfigurationWizardPage.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/wizards/SelectLanguageConfigurationWizardPage.java
@@ -58,7 +58,7 @@ import org.eclipse.ui.dialogs.ResourceSelectionDialog;
 public class SelectLanguageConfigurationWizardPage extends WizardPage implements Listener {
 	private static final String PAGE_NAME = SelectLanguageConfigurationWizardPage.class.getName();
 
-	protected static final String[] TEXTMATE_EXTENSIONS = new String[] { "*language-configuration.json" }; //$NON-NLS-1$
+	protected static final String[] TEXTMATE_EXTENSIONS = { "*language-configuration.json" }; //$NON-NLS-1$
 
 	private Button browseFileSystemButton;
 	private Button browseWorkspaceButton;

--- a/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/ITMResource.java
+++ b/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/ITMResource.java
@@ -33,5 +33,5 @@ public interface ITMResource extends ITMDefinition {
 	 * @return the stream of the TextMate resource.
 	 * @throws IOException
 	 */
-	public InputStream getInputStream() throws IOException;
+	InputStream getInputStream() throws IOException;
 }

--- a/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/TMResource.java
+++ b/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/TMResource.java
@@ -92,15 +92,9 @@ public class TMResource implements ITMResource {
 	}
 
 	private static String convertStreamToString(InputStream is) {
-		Scanner s = null;
-		try {
-			s = new Scanner(is);
+		try (Scanner s = new Scanner(is)) {
 			s.useDelimiter("\\A");
 			return s.hasNext() ? s.next() : "";
-		} finally {
-			if (s != null) {
-				s.close();
-			}
 		}
 	}
 }

--- a/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/internal/preferences/PreferenceHelper.java
+++ b/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/internal/preferences/PreferenceHelper.java
@@ -11,7 +11,6 @@
  */
 package org.eclipse.tm4e.registry.internal.preferences;
 
-import java.lang.reflect.Type;
 import java.util.Collection;
 
 import org.eclipse.tm4e.registry.GrammarDefinition;
@@ -31,12 +30,8 @@ public class PreferenceHelper {
 
 	static {
 		DEFAULT_GSON = new GsonBuilder()
-				.registerTypeAdapter(IGrammarDefinition.class, new InstanceCreator<GrammarDefinition>() {
-					@Override
-					public GrammarDefinition createInstance(Type type) {
-						return new GrammarDefinition();
-					}
-				}).create();
+				.registerTypeAdapter(IGrammarDefinition.class, (InstanceCreator<GrammarDefinition>) type -> new GrammarDefinition())
+				.create();
 	}
 
 	public static IGrammarDefinition[] loadGrammars(String json) {

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/menus/ThemeContribution.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/menus/ThemeContribution.java
@@ -48,7 +48,7 @@ public class ThemeContribution extends CompoundContributionItem implements IWork
 
 	@Override
 	protected IContributionItem[] getContributionItems() {
-		List<IContributionItem> items = new ArrayList<IContributionItem>();
+		List<IContributionItem> items = new ArrayList<>();
 		if (handlerService != null) {
 			IEditorPart editorPart = getActivePart(handlerService.getCurrentState());
 			if (editorPart != null) {

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/model/DocumentInputStream.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/model/DocumentInputStream.java
@@ -21,7 +21,7 @@ import org.eclipse.jface.text.IDocument;
  */
 public class DocumentInputStream extends InputStream {
 	
-	private IDocument fDocument;
+	private final IDocument fDocument;
 	private int fCurrPos;
 	
 	public DocumentInputStream(IDocument document) {

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/model/DocumentLineList.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/model/DocumentLineList.java
@@ -31,7 +31,7 @@ import org.eclipse.tm4e.ui.TMUIPlugin;
 public class DocumentLineList extends AbstractLineList {
 
 	private final IDocument document;
-	private InternalListener listener;
+	private final InternalListener listener;
 
 	public DocumentLineList(IDocument document) {
 		this.document = document;

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/model/TMDocumentModel.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/model/TMDocumentModel.java
@@ -16,7 +16,7 @@ import org.eclipse.tm4e.core.model.TMModel;
 
 public class TMDocumentModel extends TMModel {
 
-	private IDocument document;
+	private final IDocument document;
 
 	public TMDocumentModel(IDocument document) {
 		super(new DocumentLineList(document));

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/preferences/PreferenceHelper.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/preferences/PreferenceHelper.java
@@ -11,7 +11,6 @@
  */
 package org.eclipse.tm4e.ui.internal.preferences;
 
-import java.lang.reflect.Type;
 import java.util.Collection;
 
 import org.eclipse.tm4e.ui.themes.IThemeAssociation;
@@ -30,12 +29,7 @@ public class PreferenceHelper {
 	private static final Gson DEFAULT_GSON;
 
 	static {
-		DEFAULT_GSON = new GsonBuilder().registerTypeAdapter(IThemeAssociation.class, new InstanceCreator<ThemeAssociation>() {
-			@Override
-			public ThemeAssociation createInstance(Type type) {
-				return new ThemeAssociation();
-			}
-		}).create();
+		DEFAULT_GSON = new GsonBuilder().registerTypeAdapter(IThemeAssociation.class, (InstanceCreator<ThemeAssociation>) type -> new ThemeAssociation()).create();
 	}
 
 	public static IThemeAssociation[] loadThemeAssociations(String json) {

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/snippets/SnippetManager.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/snippets/SnippetManager.java
@@ -24,7 +24,7 @@ import org.eclipse.tm4e.ui.snippets.ISnippetManager;
 
 public class SnippetManager implements ISnippetManager {
 
-	private static final ISnippet[] EMPTY_SNIPPETS = new ISnippet[0];
+	private static final ISnippet[] EMPTY_SNIPPETS = {};
 
 	private static final String SNIPPET_ELT = "snippet";
 

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/text/TMPresentationReconcilerTestGenerator.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/text/TMPresentationReconcilerTestGenerator.java
@@ -26,7 +26,7 @@ public class TMPresentationReconcilerTestGenerator
 	private ITextViewer viewer;
 	private IDocument document;
 
-	private StringBuilder code = new StringBuilder();
+	private final StringBuilder code = new StringBuilder();
 
 	/*private List<Command> commands;
 

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/themes/AbstractThemeManager.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/themes/AbstractThemeManager.java
@@ -79,9 +79,8 @@ public abstract class AbstractThemeManager implements IThemeManager {
 	@Override
 	public ITheme[] getThemes(boolean dark) {
 		Collection<ITheme> themes = this.themes.values();
-		return themes.stream().filter(theme -> {
-			return theme.isDark() == dark;
-		}).collect(Collectors.toList()).toArray(new ITheme[0]);
+		return themes.stream().filter(theme -> (theme.isDark() == dark))
+		   .collect(Collectors.toList()).toArray(new ITheme[0]);
 	}
 
 	@Override

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/themes/BaseThemeAssociationRegistry.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/themes/BaseThemeAssociationRegistry.java
@@ -28,7 +28,7 @@ public class BaseThemeAssociationRegistry {
 
 	private IThemeAssociation defaultAssociation;
 	private final Map<String /* E4 Theme id */, List<IThemeAssociation>> eclipseThemeIds;
-	private List<IThemeAssociation> allAssociations;
+	private final List<IThemeAssociation> allAssociations;
 
 	public BaseThemeAssociationRegistry() {
 		eclipseThemeIds = new HashMap<>();

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/themes/ThemeAssociationRegistry.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/themes/ThemeAssociationRegistry.java
@@ -27,7 +27,7 @@ public class ThemeAssociationRegistry {
 
 	private final Map<String, EclipseThemeAssociation> scopes;
 
-	private class EclipseThemeAssociation {
+	private static class EclipseThemeAssociation {
 
 		private IThemeAssociation light;
 		private IThemeAssociation dark;

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/widgets/ThemeAssociationsWidget.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/widgets/ThemeAssociationsWidget.java
@@ -55,7 +55,7 @@ public class ThemeAssociationsWidget extends TableAndButtonsWidget {
 		editButton = new Button(parent, SWT.PUSH);
 		editButton.setText(TMUIMessages.Button_edit);
 		editButton.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-		editButton.addListener(SWT.Selection, (e) -> {
+		editButton.addListener(SWT.Selection, e -> {
 			// Open the wizard to create association between theme and grammar.
 			CreateThemeAssociationWizard wizard = new CreateThemeAssociationWizard(false);
 			wizard.setInitialDefinition(definition);
@@ -73,7 +73,7 @@ public class ThemeAssociationsWidget extends TableAndButtonsWidget {
 		removeButton = new Button(parent, SWT.PUSH);
 		removeButton.setText(TMUIMessages.Button_remove);
 		removeButton.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-		removeButton.addListener(SWT.Selection, (e) -> {
+		removeButton.addListener(SWT.Selection, e -> {
 
 			if (MessageDialog.openConfirm(getShell(), TMUIMessages.ThemeAssociationsWidget_remove_dialog_title,
 					TMUIMessages.ThemeAssociationsWidget_remove_dialog_message)) {

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/widgets/ThemeAssociationsWidget.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/widgets/ThemeAssociationsWidget.java
@@ -36,7 +36,7 @@ import org.eclipse.tm4e.ui.themes.IThemeManager;
  */
 public class ThemeAssociationsWidget extends TableAndButtonsWidget {
 
-	private IThemeManager themeManager;
+	private final IThemeManager themeManager;
 
 	private Button editButton;
 	private Button removeButton;

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/wizards/SelectGrammarWizardPage.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/wizards/SelectGrammarWizardPage.java
@@ -45,7 +45,7 @@ public class SelectGrammarWizardPage extends AbstractWizardPage {
 
 	private static final String PAGE_NAME = SelectGrammarWizardPage.class.getName();
 
-	protected static final String[] TEXTMATE_EXTENSIONS = new String[] {"*.tmLanguage","*.json"};
+	protected static final String[] TEXTMATE_EXTENSIONS = {"*.tmLanguage","*.json"};
 
 	private Button browseFileSystemButton;
 	private Button browseWorkspaceButton;

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/themes/ThemeIdConstants.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/themes/ThemeIdConstants.java
@@ -17,9 +17,9 @@ package org.eclipse.tm4e.ui.themes;
  */
 public interface ThemeIdConstants {
 
-	public static final String Light = "org.eclipse.tm4e.ui.themes.Light";
-	public static final String Monokai = "org.eclipse.tm4e.ui.themes.Monokai";
-	public static final String SolarizedLight = "org.eclipse.tm4e.ui.themes.SolarizedLight";
-	public static final String Dark = "org.eclipse.tm4e.ui.themes.Dark";
+	String Light = "org.eclipse.tm4e.ui.themes.Light";
+	String Monokai = "org.eclipse.tm4e.ui.themes.Monokai";
+	String SolarizedLight = "org.eclipse.tm4e.ui.themes.SolarizedLight";
+	String Dark = "org.eclipse.tm4e.ui.themes.Dark";
 
 }

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/themes/css/CSSTokenProvider.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/themes/css/CSSTokenProvider.java
@@ -31,7 +31,7 @@ import org.eclipse.tm4e.ui.themes.ColorManager;
 
 public class CSSTokenProvider extends AbstractTokenProvider {
 
-	private Map<IStyle, IToken> tokenMaps;
+	private final Map<IStyle, IToken> tokenMaps;
 	private CSSParser parser;
 
 	public CSSTokenProvider(InputStream in) {


### PR DESCRIPTION
I ran the Eclipse Code Cleanup action with a few uncritical rules.

Apparently a few files where committed with wrong line endings before. So better do a diff ignoring whitespaces using `?w=1`: https://github.com/eclipse/tm4e/pull/302/files?w=1