### PR TITLE
Evaluate command as enter when text equals delimiter

### DIFF
--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/utils/TextUtils.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/utils/TextUtils.java
@@ -30,7 +30,7 @@ public class TextUtils {
 	 * @return true if text of the command is an enter and false otherwise.
 	 */
 	public static boolean isEnter(IDocument d, DocumentCommand c) {
-		return (c.length == 0 && c.text != null && TextUtilities.endsWith(d.getLegalLineDelimiters(), c.text) != -1);
+		return (c.length == 0 && c.text != null && TextUtilities.equals(d.getLegalLineDelimiters(), c.text) != -1);
 	}
 
 	public static String normalizeIndentation(String str, int tabSize, boolean insertSpaces) {


### PR DESCRIPTION
## Explanation of the bug
Hello! I found a bug in the `TextUtils.isEnter(IDocument d, DocumentCommand c)` method. I put an explanation of the bug in the description of the commit. TLDR - the function identifies document commands with a 0 length selection and clipboard text ending in a delimiter as an enter key press.

## Merging the pull request
We currently use the `0.1.0` release in our product. Since there isn't a maintenance branch for the `0.1.0` release, I opened this pull request against the `master` branch. I believe a maintainer will need to create a new branch from the `0.1.0` tag, and change this pull request's base to that new branch. Lastly, they would commit any version updates, create a `0.1.1` tag, and run a build. All of this assuming you agree with my change!

## How we consume builds
Our build pulls from the [tm4e software repository](https://archive.eclipse.org/tm4e/releases/) downloads. Ideally your pipeline publishes the new version there. Thanks for the help and active maintenance of this project!