### PR TITLE
Clear snippet preview if none provided

### DIFF
--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/preferences/GrammarPreferencePage.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/preferences/GrammarPreferencePage.java
@@ -301,7 +301,9 @@ public class GrammarPreferencePage extends PreferencePage implements IWorkbenchP
 
 				// Snippet
 				ISnippet[] snippets = snippetManager.getSnippets(scopeName);
-				if (snippets != null && snippets.length > 0) {
+				if (snippets == null || snippets.length == 0) {
+					previewViewer.setText("");
+				} else {
 					// TODO: manage list of snippet for the given scope.
 					previewViewer.setText(snippets[0].getContent());
 				}


### PR DESCRIPTION
When switching from a grammar that provides a snippet to a grammar that does not. The snippet preview is not cleared and still shows the snippet from the unrelated grammar and wrong syntax highlighing is applied. This PR clears the snippet preview text field in case a grammar is selected that does not provide snippets.