### PR TITLE
Rename PListFormatsTest to GrammarReaderTest

### DIFF
--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/parser/Raw.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/parser/Raw.java
@@ -1,14 +1,14 @@
 /**
- *  Copyright (c) 2015-2019 Angelo ZERR.
+ * Copyright (c) 2015-2019 Angelo ZERR.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
  *
- *  Contributors:
- *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
- *  Pierre-Yves B. - Issue #221 NullPointerException when retrieving fileTypes
+ * Contributors:
+ * Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
+ * Pierre-Yves B. - Issue #221 NullPointerException when retrieving fileTypes
  */
 package org.eclipse.tm4e.core.internal.grammar.parser;
 
@@ -53,7 +53,8 @@ public class Raw extends HashMap<String, Object> implements IRawRepository, IRaw
 	private static final String DOLLAR_SELF = "$self";
 	private static final String DOLLAR_BASE = "$base";
 	private static final long serialVersionUID = -2306714541728887963L;
-	private List<String> fileTypes;
+
+	private transient List<String> fileTypes;
 
 	@Override
 	public IRawRule getProp(String name) {
@@ -264,20 +265,20 @@ public class Raw extends HashMap<String, Object> implements IRawRepository, IRaw
 
 	@Override
 	public Collection<String> getFileTypes() {
-		if(fileTypes==null) {
-			List<String> list=new ArrayList<>();
+		if (fileTypes == null) {
+			List<String> list = new ArrayList<>();
 			Collection<?> unparsedFileTypes = (Collection<?>) super.get(FILE_TYPES);
 			if (unparsedFileTypes != null) {
-				for(Object o: unparsedFileTypes) {
-					String str=o.toString();
+				for (Object o : unparsedFileTypes) {
+					String str = o.toString();
 					// #202
-					if(str.startsWith(".")) {
-						str=str.substring(1);
+					if (str.startsWith(".")) {
+						str = str.substring(1);
 					}
 					list.add(str);
 				}
 			}
-			fileTypes=list;
+			fileTypes = list;
 		}
 		return fileTypes;
 	}
@@ -303,27 +304,17 @@ public class Raw extends HashMap<String, Object> implements IRawRepository, IRaw
 	}
 
 	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (!super.equals(obj))
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		Raw other = (Raw) obj;
-		if (fileTypes == null) {
-			if (other.fileTypes != null)
-				return false;
-		} else if (!fileTypes.equals(other.fileTypes))
-			return false;
-		return true;
+	public Object put(String key, Object value) {
+		if (FILE_TYPES.equals(key))
+			fileTypes = null;
+		return super.put(key, value);
 	}
 
 	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = super.hashCode();
-		result = prime * result + ((fileTypes == null) ? 0 : fileTypes.hashCode());
-		return result;
+	@SuppressWarnings("unlikely-arg-type")
+	public void putAll(Map<? extends String, ? extends Object> m) {
+		if (m != null && m.containsKey(FILE_TYPES))
+			fileTypes = null;
+		super.putAll(m);
 	}
 }

--- a/org.eclipse.tm4e.core/src/test/java/org/eclipse/tm4e/core/internal/grammar/reader/GrammarReaderTest.java
+++ b/org.eclipse.tm4e.core/src/test/java/org/eclipse/tm4e/core/internal/grammar/reader/GrammarReaderTest.java
@@ -10,18 +10,17 @@
  * Contributors:
  * Sebastian Thomschke - initial implementation
  */
-package org.eclipse.tm4e.core.internal.grammar.parser;
+package org.eclipse.tm4e.core.internal.grammar.reader;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.InputStream;
 
 import org.eclipse.tm4e.core.Data;
-import org.eclipse.tm4e.core.internal.grammar.reader.GrammarReader;
 import org.eclipse.tm4e.core.internal.types.IRawGrammar;
 import org.junit.jupiter.api.Test;
 
-public class PlistFormatsTest {
+public class GrammarReaderTest {
 
 	private IRawGrammar loadGrammar(String path) throws Exception {
 		try (InputStream is = Data.class.getResourceAsStream(path)) {
@@ -29,13 +28,20 @@ public class PlistFormatsTest {
 		}
 	}
 
+	/**
+	 * Loads the same TextMate grammar in different formats and checks
+	 * loading them results in equal IRawGrammar objects.
+	 */
 	@Test
-	public void testPlistFormats() throws Exception {
+	public void testLoadDifferentPlistFormats() throws Exception {
 		IRawGrammar grammarFromXML = loadGrammar("JavaScript.tmLanguage");
 		IRawGrammar grammarFromJSON = loadGrammar("JavaScript.tmLanguage.json");
 		IRawGrammar grammarFromYAML = loadGrammar("JavaScript.tmLanguage.yaml");
 
+		assertNotNull(grammarFromXML);
+		assertFalse(grammarFromXML.getFileTypes().isEmpty());
+
 		assertEquals(grammarFromXML, grammarFromJSON);
-		assertEquals(grammarFromXML, grammarFromYAML);
+		assertEquals(grammarFromJSON, grammarFromYAML);
 	}
 }


### PR DESCRIPTION
Renames/moves the `internal.grammar.parser.PListFormatsTest` to `internal.grammar.reader.GrammarReaderTest`, since the test mainly uses the GrammarReader from this package.
I also added some assertions and JavaDoc.