### PR TITLE
Fix StringIndexOutOfBoundsException in LineTokens

### DIFF
--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/LineTokens.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/LineTokens.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright (c) 2015-2017 Angelo ZERR.
+ *  Copyright (c) 2015-2022 Angelo ZERR.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -85,12 +85,12 @@ class LineTokens {
 		List<String> scopes = scopesList.generateScopes();
 
 		if (this.lineText != null) {
-			LOGGER.info("  token: |" + this.lineText.substring(this.lastTokenEndIndex, endIndex).replaceAll("\n", "\\n") + '|');
+			LOGGER.info("  token: |" + this.lineText.substring(this.lastTokenEndIndex >= 0 ? this.lastTokenEndIndex : 0, endIndex).replaceAll("\n", "\\n") + '|');
 			for (String scope : scopes) {
 				LOGGER.info("      * " + scope);
 			}
 		}
-		this.tokens.add(new Token(this.lastTokenEndIndex, endIndex, scopes));
+		this.tokens.add(new Token(this.lastTokenEndIndex >= 0 ? this.lastTokenEndIndex : 0, endIndex, scopes));
 
 		this.lastTokenEndIndex = endIndex;
 	}


### PR DESCRIPTION
An error message appears in log due to StringIndexOutOfBoundsException exception occuring in TMModel.TokenizerThread:

!ENTRY org.eclipse.tm4e.core 4 0 2022-04-14 13:10:05.298
!MESSAGE begin -1, end 1, length 1

The cause of the error logged is the following exception:

Apr 14, 2022 1:10:05 PM org.eclipse.tm4e.core.model.TMModel$TokenizerThread updateTokensInRange
SEVERE: begin -1, end 1, length 1

java.lang.StringIndexOutOfBoundsException: begin -1, end 1, length 1
	at java.base/java.lang.String.checkBoundsBeginEnd(String.java:4601)
	at java.base/java.lang.String.substring(String.java:2704)
	at org.eclipse.tm4e.core.internal.grammar.LineTokens.produceFromScopes(LineTokens.java:88)
	at org.eclipse.tm4e.core.internal.grammar.LineTokens.produce(LineTokens.java:62)
	at org.eclipse.tm4e.core.internal.grammar.LineTokens.getResult(LineTokens.java:106)
	at org.eclipse.tm4e.core.internal.grammar.Grammar.tokenize(Grammar.java:248)
	at org.eclipse.tm4e.core.internal.grammar.Grammar.tokenizeLine(Grammar.java:194)
	at org.eclipse.tm4e.core.model.Tokenizer.tokenize(Tokenizer.java:65)
	at org.eclipse.tm4e.core.model.TMModel$TokenizerThread.updateTokensInRange(TMModel.java:191)
	at org.eclipse.tm4e.core.model.TMModel$TokenizerThread.lambda$0(Unknown Source)
	at org.eclipse.tm4e.core.model.TMModel.buildEventWithCallback(Unknown Source)
	at org.eclipse.tm4e.core.model.TMModel$TokenizerThread.revalidateTokensNow(Unknown Source)
	at org.eclipse.tm4e.core.model.TMModel$TokenizerThread.run(Unknown Source)

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>