### PR TITLE
Fix "SWT Resource was not properly disposed"

### DIFF
--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/widgets/AutoClosingPairConditionalTableWidget.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/widgets/AutoClosingPairConditionalTableWidget.java
@@ -26,6 +26,7 @@ public class AutoClosingPairConditionalTableWidget extends CharacterPairsTableWi
 	public AutoClosingPairConditionalTableWidget(Table table) {
 		super(table);
 		setLabelProvider(new AutoClosingPairConditionalLabelProvider());
+
 		GC gc = new GC(table.getShell());
 		gc.setFont(JFaceResources.getDialogFont());
 		TableColumnLayout columnLayout = new TableColumnLayout();
@@ -35,6 +36,8 @@ public class AutoClosingPairConditionalTableWidget extends CharacterPairsTableWi
 		int minWidth = computeMinimumColumnWidth(gc,
 				LanguageConfigurationMessages.AutoClosingPairConditionalTableWidget_notIn);
 		columnLayout.setColumnData(column2, new ColumnWeightData(2, minWidth, true));
+
+		gc.dispose();
 	}
 
 	protected class AutoClosingPairConditionalLabelProvider extends CharacterPairLabelProvider {

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/widgets/CharacterPairsTableWidget.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/widgets/CharacterPairsTableWidget.java
@@ -50,6 +50,8 @@ public class CharacterPairsTableWidget extends TableViewer {
 		column2.setText(LanguageConfigurationMessages.CharacterPairsTableWidget_end);
 		minWidth = computeMinimumColumnWidth(gc, LanguageConfigurationMessages.CharacterPairsTableWidget_end);
 		columnLayout.setColumnData(column2, new ColumnWeightData(2, minWidth, true));
+
+		gc.dispose();
 	}
 
 	protected int computeMinimumColumnWidth(GC gc, String string) {

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/widgets/OnEnterRuleTableWidget.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/widgets/OnEnterRuleTableWidget.java
@@ -66,6 +66,8 @@ public class OnEnterRuleTableWidget extends TableViewer {
 		column5.setText(LanguageConfigurationMessages.OnEnterRuleTableWidget_removeText);
 		minWidth = computeMinimumColumnWidth(gc, LanguageConfigurationMessages.OnEnterRuleTableWidget_removeText);
 		columnLayout.setColumnData(column5, new ColumnWeightData(1, minWidth, true));
+
+		gc.dispose();
 	}
 
 	protected int computeMinimumColumnWidth(GC gc, String string) {


### PR DESCRIPTION
This fixes:
```java
java.lang.Error: SWT Resource was not properly disposed
	at org.eclipse.swt.graphics.Resource.initNonDisposeTracking(Resource.java:172)
	at org.eclipse.swt.graphics.Resource.<init>(Resource.java:113)
	at org.eclipse.swt.graphics.GC.<init>(GC.java:167)
	at org.eclipse.swt.graphics.GC.<init>(GC.java:135)
	at org.eclipse.tm4e.languageconfiguration.internal.widgets.CharacterPairsTableWidget.<init>(CharacterPairsTableWidget.java:40)
	at org.eclipse.tm4e.languageconfiguration.internal.widgets.AutoClosingPairConditionalTableWidget.<init>(AutoClosingPairConditionalTableWidget.java:27)
	at org.eclipse.tm4e.languageconfiguration.internal.widgets.LanguageConfigurationInfoWidget.createAutoClosingPairsTab(LanguageConfigurationInfoWidget.java:161)
	at org.eclipse.tm4e.languageconfiguration.internal.widgets.LanguageConfigurationPreferencesWidget.createAutoClosingPairsTab(LanguageConfigurationPreferencesWidget.java:83)
	at org.eclipse.tm4e.languageconfiguration.internal.widgets.LanguageConfigurationInfoWidget.createUI(LanguageConfigurationInfoWidget.java:80)
	at org.eclipse.tm4e.languageconfiguration.internal.widgets.LanguageConfigurationInfoWidget.<init>(LanguageConfigurationInfoWidget.java:44)
	at org.eclipse.tm4e.languageconfiguration.internal.widgets.LanguageConfigurationPreferencesWidget.<init>(LanguageConfigurationPreferencesWidget.java:34)
	at org.eclipse.tm4e.languageconfiguration.internal.preferences.LanguageConfigurationPreferencePage.createContents(LanguageConfigurationPreferencePage.java:104)
	at org.eclipse.jface.preference.PreferencePage.createControl(PreferencePage.java:244)
	at org.eclipse.jface.preference.PreferenceDialog.createPageControl(PreferenceDialog.java:1433)
	at org.eclipse.jface.preference.PreferenceDialog$8.run(PreferenceDialog.java:1196)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:45)
	at org.eclipse.jface.util.SafeRunnable.run(SafeRunnable.java:174)
	at org.eclipse.jface.preference.PreferenceDialog.showPage(PreferenceDialog.java:1188)
	at org.eclipse.ui.internal.dialogs.FilteredPreferenceDialog.showPage(FilteredPreferenceDialog.java:630)
	at org.eclipse.jface.preference.PreferenceDialog$5.lambda$0(PreferenceDialog.java:660)
	at org.eclipse.swt.custom.BusyIndicator.showWhile(BusyIndicator.java:74)
	at org.eclipse.jface.preference.PreferenceDialog$5.selectionChanged(PreferenceDialog.java:657)
	at org.eclipse.jface.viewers.StructuredViewer$3.run(StructuredViewer.java:823)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:45)
	at org.eclipse.jface.util.SafeRunnable.run(SafeRunnable.java:174)
	at org.eclipse.jface.viewers.StructuredViewer.firePostSelectionChanged(StructuredViewer.java:820)
	at org.eclipse.jface.viewers.StructuredViewer.handlePostSelect(StructuredViewer.java:1193)
	at org.eclipse.swt.events.SelectionListener$1.widgetSelected(SelectionListener.java:84)
	at org.eclipse.jface.util.OpenStrategy.firePostSelectionEvent(OpenStrategy.java:263)
	at org.eclipse.jface.util.OpenStrategy.access$5(OpenStrategy.java:258)
	at org.eclipse.jface.util.OpenStrategy$1.lambda$1(OpenStrategy.java:428)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:40)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:185)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:4001)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3629)
	at org.eclipse.jface.window.Window.runEventLoop(Window.java:823)
	at org.eclipse.jface.window.Window.open(Window.java:799)
	at org.eclipse.ui.internal.OpenPreferencesAction.run(OpenPreferencesAction.java:66)
	at org.eclipse.jface.action.Action.runWithEvent(Action.java:474)
	at org.eclipse.jface.action.ActionContributionItem.handleWidgetSelection(ActionContributionItem.java:580)
	at org.eclipse.jface.action.ActionContributionItem.lambda$4(ActionContributionItem.java:414)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:89)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:4209)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1043)
	at org.eclipse.swt.widgets.Display.runDeferredEvents(Display.java:4026)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3626)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$5.run(PartRenderingEngine.java:1157)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:338)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1046)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:155)
	at org.eclipse.ui.internal.Workbench.lambda$3(Workbench.java:644)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:338)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:551)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:156)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:152)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:203)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:134)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:401)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:255)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:653)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:590)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1461)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1434)
```

and
```java
java.lang.Error: SWT Resource was not properly disposed
	at org.eclipse.swt.graphics.Resource.initNonDisposeTracking(Resource.java:172)
	at org.eclipse.swt.graphics.Resource.<init>(Resource.java:113)
	at org.eclipse.swt.graphics.GC.<init>(GC.java:167)
	at org.eclipse.swt.graphics.GC.<init>(GC.java:135)
	at org.eclipse.tm4e.languageconfiguration.internal.widgets.OnEnterRuleTableWidget.<init>(OnEnterRuleTableWidget.java:41)
	at org.eclipse.tm4e.languageconfiguration.internal.widgets.LanguageConfigurationInfoWidget.createOnEnterRulesTab(LanguageConfigurationInfoWidget.java:193)
	at org.eclipse.tm4e.languageconfiguration.internal.widgets.LanguageConfigurationPreferencesWidget.createOnEnterRulesTab(LanguageConfigurationPreferencesWidget.java:60)
	at org.eclipse.tm4e.languageconfiguration.internal.widgets.LanguageConfigurationInfoWidget.createUI(LanguageConfigurationInfoWidget.java:84)
	at org.eclipse.tm4e.languageconfiguration.internal.widgets.LanguageConfigurationInfoWidget.<init>(LanguageConfigurationInfoWidget.java:44)
	at org.eclipse.tm4e.languageconfiguration.internal.widgets.LanguageConfigurationPreferencesWidget.<init>(LanguageConfigurationPreferencesWidget.java:34)
	at org.eclipse.tm4e.languageconfiguration.internal.preferences.LanguageConfigurationPreferencePage.createContents(LanguageConfigurationPreferencePage.java:104)
	at org.eclipse.jface.preference.PreferencePage.createControl(PreferencePage.java:244)
	at org.eclipse.jface.preference.PreferenceDialog.createPageControl(PreferenceDialog.java:1433)
	at org.eclipse.jface.preference.PreferenceDialog$8.run(PreferenceDialog.java:1196)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:45)
	at org.eclipse.jface.util.SafeRunnable.run(SafeRunnable.java:174)
	at org.eclipse.jface.preference.PreferenceDialog.showPage(PreferenceDialog.java:1188)
	at org.eclipse.ui.internal.dialogs.FilteredPreferenceDialog.showPage(FilteredPreferenceDialog.java:630)
	at org.eclipse.jface.preference.PreferenceDialog$5.lambda$0(PreferenceDialog.java:660)
	at org.eclipse.swt.custom.BusyIndicator.showWhile(BusyIndicator.java:74)
	at org.eclipse.jface.preference.PreferenceDialog$5.selectionChanged(PreferenceDialog.java:657)
	at org.eclipse.jface.viewers.StructuredViewer$3.run(StructuredViewer.java:823)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:45)
	at org.eclipse.jface.util.SafeRunnable.run(SafeRunnable.java:174)
	at org.eclipse.jface.viewers.StructuredViewer.firePostSelectionChanged(StructuredViewer.java:820)
	at org.eclipse.jface.viewers.StructuredViewer.handlePostSelect(StructuredViewer.java:1193)
	at org.eclipse.swt.events.SelectionListener$1.widgetSelected(SelectionListener.java:84)
	at org.eclipse.jface.util.OpenStrategy.firePostSelectionEvent(OpenStrategy.java:263)
	at org.eclipse.jface.util.OpenStrategy.access$5(OpenStrategy.java:258)
	at org.eclipse.jface.util.OpenStrategy$1.lambda$1(OpenStrategy.java:428)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:40)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:185)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:4001)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3629)
	at org.eclipse.jface.window.Window.runEventLoop(Window.java:823)
	at org.eclipse.jface.window.Window.open(Window.java:799)
	at org.eclipse.ui.internal.OpenPreferencesAction.run(OpenPreferencesAction.java:66)
	at org.eclipse.jface.action.Action.runWithEvent(Action.java:474)
	at org.eclipse.jface.action.ActionContributionItem.handleWidgetSelection(ActionContributionItem.java:580)
	at org.eclipse.jface.action.ActionContributionItem.lambda$4(ActionContributionItem.java:414)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:89)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:4209)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1043)
	at org.eclipse.swt.widgets.Display.runDeferredEvents(Display.java:4026)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3626)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$5.run(PartRenderingEngine.java:1157)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:338)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1046)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:155)
	at org.eclipse.ui.internal.Workbench.lambda$3(Workbench.java:644)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:338)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:551)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:156)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:152)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:203)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:134)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:401)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:255)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:653)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:590)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1461)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1434)
```