### PR TITLE
Upgrade org.joni

### DIFF
--- a/org.eclipse.tm4e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.core/META-INF/MANIFEST.MF
@@ -9,8 +9,8 @@ Require-Bundle: org.apache.batik.css;bundle-version="1.9.1";resolution:=optional
  org.apache.batik.util;bundle-version="1.9.1";resolution:=optional,
  com.google.gson;resolution:=optional,
  com.google.guava;bundle-version="30.1.0",
- org.jcodings;bundle-version="1.0.18",
- org.joni;bundle-version="2.1.11",
+ org.jcodings;bundle-version="1.0.57",
+ org.joni;bundle-version="2.1.43",
  org.yaml.snakeyaml;bundle-version="1.27.0"
 Import-Package: org.w3c.css.sac;resolution:=optional,
  org.w3c.css.sac.helpers;resolution:=optional,

--- a/target-platform/tm4e-target.target
+++ b/target-platform/tm4e-target.target
@@ -1,30 +1,47 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
 <target name="tm4e" sequenceNumber="9">
-<locations>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.license.feature.group" version="2.0.2.v20181016-2210"/>
-<repository location="https://download.eclipse.org/cbi/updates/license/2.0.2.v20181016-2210/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="com.google.gson" version="2.8.9.v20220111-1409"/>
-<unit id="com.google.guava" version="30.1.0.v20210127-2300"/>
-<unit id="org.jcodings" version="1.0.18.v20170306-1742"/>
-<unit id="org.joni" version="2.1.11.v20170306-1742"/>
-<unit id="org.apache.batik.css" version="1.14.0.v20210324-0332"/>
-<unit id="org.yaml.snakeyaml" version="1.27.0.v20201111-1638"/>
-<repository location="https://download.eclipse.org/tools/orbit/downloads/latest-S/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.ui.tests.harness" version="0.0.0"/>
-<unit id="org.eclipse.jdt.annotation" version="0.0.0"/>
-<unit id="org.junit" version="0.0.0"/>
-<unit id="org.junit.jupiter.api" version="0.0.0"/>
-<unit id="org.eclipse.jdt.junit5.runtime" version="0.0.0"/>
-<unit id="org.eclipse.ui.trace" version="0.0.0"/>
-<repository location="https://download.eclipse.org/eclipse/updates/4.22/"/>
-</location>
-</locations>
-	<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+    <locations>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <unit id="org.eclipse.license.feature.group" version="2.0.2.v20181016-2210"/>
+            <repository location="https://download.eclipse.org/cbi/updates/license/2.0.2.v20181016-2210/"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <unit id="com.google.gson" version="2.8.9.v20220111-1409"/>
+            <unit id="com.google.guava" version="30.1.0.v20210127-2300"/>
+            <unit id="org.apache.batik.css" version="1.14.0.v20210324-0332"/>
+            <unit id="org.yaml.snakeyaml" version="1.27.0.v20201111-1638"/>
+            <repository location="https://download.eclipse.org/tools/orbit/downloads/latest-S/"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
+            <unit id="org.eclipse.ui.tests.harness" version="0.0.0"/>
+            <unit id="org.eclipse.jdt.annotation" version="0.0.0"/>
+            <unit id="org.junit" version="0.0.0"/>
+            <unit id="org.junit.jupiter.api" version="0.0.0"/>
+            <unit id="org.eclipse.jdt.junit5.runtime" version="0.0.0"/>
+            <unit id="org.eclipse.ui.trace" version="0.0.0"/>
+            <repository location="https://download.eclipse.org/eclipse/updates/4.22/"/>
+        </location>
+        <location includeDependencyDepth="direct" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
+            <dependencies>
+                <dependency>
+                    <groupId>org.jruby.joni</groupId>
+                    <artifactId>joni</artifactId>
+                    <version>2.1.43</version>
+                    <type>jar</type>
+                </dependency>
+            </dependencies>
+            <instructions><![CDATA[
+Bundle-Name:           Bundle derived from maven artifact ${mvnGroupId}:${mvnArtifactId}:${mvnVersion}
+version:               ${version_cleanup;${mvnVersion}}
+Bundle-SymbolicName:   org.${mvnArtifactId}
+Bundle-Version:        ${version}
+Import-Package:        *;resolution:=optional
+Export-Package:        *;version="${version}";-noimport:=true
+DynamicImport-Package: *
+]]></instructions>
+        </location>
+    </locations>
+    <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 </target>


### PR DESCRIPTION
Rational: Currently used version 2.1.11 is 7 years old. Numerous improvements have been made to the library since then. Including support for more syntax features. https://github.com/jruby/joni/compare/joni-2.1.11...joni-2.1.43