### PR TITLE
Use .isEmpty() instead of .size() or .length() for emptiness check

### DIFF
--- a/org.eclipse.tm4e.core.tests/src/main/java/org/eclipse/tm4e/core/grammar/internal/RawTestImpl.java
+++ b/org.eclipse.tm4e.core.tests/src/main/java/org/eclipse/tm4e/core/grammar/internal/RawTestImpl.java
@@ -119,9 +119,9 @@ public class RawTestImpl {
 
 		List<RawToken> expectedTokens = testCase.getTokens();
 		// // TODO@Alex: fix tests instead of working around
-		if (testCase.getLine().length() > 0) {
+		if (!testCase.getLine().isEmpty()) {
 			// Remove empty tokens...
-			expectedTokens = testCase.getTokens().stream().filter(token -> token.getValue().length() > 0)
+			expectedTokens = testCase.getTokens().stream().filter(token -> !token.getValue().isEmpty())
 					.collect(Collectors.toList());
 		}
 		deepEqual(actualTokens, expectedTokens, "Tokenizing line '" + testCase.getLine() + "'");

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/LineTokenizer.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/LineTokenizer.java
@@ -291,7 +291,7 @@ class LineTokenizer {
 
 		// Look for injected rules
 		List<Injection> injections = grammar.getInjections();
-		if (injections.size() == 0) {
+		if (injections.isEmpty()) {
 			// No injections whatsoever => early return
 			return matchResult;
 		}

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/utils/RegexSource.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/utils/RegexSource.java
@@ -65,7 +65,7 @@ public class RegexSource {
 		if (capture != null) {
 			String result = captureSource.substring(capture.getStart(), capture.getEnd());
 			// Remove leading dots that would make the selector invalid
-			while (result.length() > 0 && result.charAt(0) == '.') {
+			while (!result.isEmpty() && result.charAt(0) == '.') {
 				result = result.substring(1);
 			}
 			if ("downcase".equals(command)) {

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/theme/Theme.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/theme/Theme.java
@@ -138,7 +138,7 @@ public class Theme {
 	}
 
 	private static boolean isValidHexColor(String hex) {
-		if (hex == null || hex.length() < 1) {
+		if (hex == null || hex.isEmpty()) {
 			return false;
 		}
 
@@ -190,7 +190,7 @@ public class Theme {
 		int defaultFontStyle = FontStyle.None;
 		String defaultForeground = "#000000";
 		String defaultBackground = "#ffffff";
-		while (parsedThemeRules.size() >= 1 && "".equals(parsedThemeRules.get(0).scope)) {
+		while (!parsedThemeRules.isEmpty() && "".equals(parsedThemeRules.get(0).scope)) {
 			ParsedThemeRule incomingDefaults = parsedThemeRules.remove(0); // shift();
 			if (incomingDefaults.fontStyle != FontStyle.NotSet) {
 				defaultFontStyle = incomingDefaults.fontStyle;

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/supports/OnEnterSupport.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/supports/OnEnterSupport.java
@@ -55,7 +55,7 @@ public class OnEnterSupport {
 		}
 
 		// (2): Special indent-outdent
-		if (beforeEnterText.length() > 0 && afterEnterText.length() > 0) {
+		if (!beforeEnterText.isEmpty() && !afterEnterText.isEmpty()) {
 			for (ProcessedBracketPair bracket : brackets) {
 				if (bracket.matchOpen(beforeEnterText) && bracket.matchClose(afterEnterText)) {
 					return new EnterAction(IndentAction.IndentOutdent);
@@ -64,7 +64,7 @@ public class OnEnterSupport {
 		}
 
 		// (3): Open bracket based logic
-		if (beforeEnterText.length() > 0) {
+		if (!beforeEnterText.isEmpty()) {
 			for (ProcessedBracketPair bracket : brackets) {
 				if (bracket.matchOpen(beforeEnterText)) {
 					return new EnterAction(IndentAction.Indent);

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/wizards/SelectLanguageConfigurationWizardPage.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/wizards/SelectLanguageConfigurationWizardPage.java
@@ -123,7 +123,7 @@ public class SelectLanguageConfigurationWizardPage extends WizardPage implements
 			page.setErrorMessage(null);
 			break;
 		default:
-			if (message != null && message.length() == 0) {
+			if (message != null && message.isEmpty()) {
 				message = null;
 			}
 			page.setMessage(null);
@@ -163,7 +163,7 @@ public class SelectLanguageConfigurationWizardPage extends WizardPage implements
 				dialog.setFilterExtensions(TEXTMATE_EXTENSIONS);
 				dialog.setFilterPath(fileText.getText());
 				String result = dialog.open();
-				if (result != null && result.length() > 0) {
+				if (result != null && !result.isEmpty()) {
 					fileText.setText(result);
 				}
 			}

--- a/org.eclipse.tm4e.markdown/src/main/java/org/eclipse/tm4e/markdown/TMHTMLRenderer.java
+++ b/org.eclipse.tm4e.markdown/src/main/java/org/eclipse/tm4e/markdown/TMHTMLRenderer.java
@@ -89,7 +89,7 @@ public class TMHTMLRenderer extends HTMLRenderer {
 
 			String className = "token";
 			String safeType = token.type.replaceAll("[^a-z0-9\\-]", " ");
-			if (safeType.length() > 0) {
+			if (!safeType.isEmpty()) {
 				className += ' ' + safeType;
 			}
 

--- a/org.eclipse.tm4e.markdown/src/main/java/org/eclipse/tm4e/markdown/marked/Helpers.java
+++ b/org.eclipse.tm4e.markdown/src/main/java/org/eclipse/tm4e/markdown/marked/Helpers.java
@@ -32,7 +32,7 @@ public class Helpers {
 	}
 
 	public static boolean isEmpty(String s) {
-		return s == null || s.length() < 1;
+		return s == null || s.isEmpty();
 	}
 
 }

--- a/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/TMResource.java
+++ b/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/TMResource.java
@@ -68,7 +68,7 @@ public class TMResource implements ITMResource {
 
 	@Override
 	public InputStream getInputStream() throws IOException {
-		if (path == null || path.length() < 0) {
+		if (path == null || path.isEmpty()) {
 			return null;
 		}
 		if (pluginId != null) {

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/model/DocumentHelper.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/model/DocumentHelper.java
@@ -33,7 +33,7 @@ public class DocumentHelper {
 	}
 
 	public static boolean isRemove(DocumentEvent event) {
-		return event.getText() == null || event.getText().length() == 0;
+		return event.getText() == null || event.getText().isEmpty();
 	}
 
 	public static boolean isInsert(DocumentEvent event) {

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/wizards/AbstractWizardPage.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/wizards/AbstractWizardPage.java
@@ -91,7 +91,7 @@ public abstract class AbstractWizardPage extends WizardPage implements Listener 
 			page.setErrorMessage(null);
 			break;
 		default:
-			if (message != null && message.length() == 0) {
+			if (message != null && message.isEmpty()) {
 				message = null;
 			}
 			page.setMessage(null);

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/wizards/SelectGrammarWizardPage.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/wizards/SelectGrammarWizardPage.java
@@ -91,7 +91,7 @@ public class SelectGrammarWizardPage extends AbstractWizardPage {
 				dialog.setFilterExtensions(TEXTMATE_EXTENSIONS);
 				dialog.setFilterPath(grammarFileText.getText());
 				String result = dialog.open();
-				if (result != null && result.length() > 0) {
+				if (result != null && !result.isEmpty()) {
 					grammarFileText.setText(result);
 				}
 			}
@@ -130,7 +130,7 @@ public class SelectGrammarWizardPage extends AbstractWizardPage {
 	protected IStatus validatePage(Event event) {
 		grammarInfoWidget.refresh(null);
 		String path = grammarFileText.getText();
-		if (path.length() == 0) {
+		if (path.isEmpty()) {
 			return new Status(IStatus.ERROR, TMUIPlugin.PLUGIN_ID,
 					TMUIMessages.SelectGrammarWizardPage_file_error_required);
 		}


### PR DESCRIPTION
Reason 1: https://rules.sonarsource.com/java/RSPEC-1155
Reason 2: Prevents bugs like: 
https://github.com/eclipse/tm4e/blob/9b15d6471723497753d0a13b2b8230cfde0034b9/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/TMResource.java#L71-L72