### PR TITLE
Define jgit.dirtyWorkingTree as configurable Maven property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
 		<sonar.jacoco.reportPath>../target/jacoco.exec</sonar.jacoco.reportPath>
 		<tycho.scmUrl>scm:git:https://github.com/eclipse/tm4e.git</tycho.scmUrl>
 		<cbi.jarsigner.skip>true</cbi.jarsigner.skip>
+		<jgit.dirtyWorkingTree>error</jgit.dirtyWorkingTree>
 	</properties>
 	<organization>
 		<name>Eclipse TM4E project</name>
@@ -181,6 +182,7 @@
 					</sourceReferences>
 					<timestampProvider>jgit</timestampProvider>
 					<jgit.ignore>pom.xml</jgit.ignore>
+					<jgit.dirtyWorkingTree>${jgit.dirtyWorkingTree}</jgit.dirtyWorkingTree>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
This allows running `mvn package -Djgit.dirtyWorkingTree=ignore` on local builds to ignore:

```
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.eclipse.tycho:tycho-packaging-plugin:2.7.1:build-qualifier 
(default-build-qualifier) on project org.eclipse.tm4e.core: Working tree is dirty.
[ERROR] git status org.eclipse.tm4e.core:
...
[ERROR] You are trying to use tycho-buildtimestamp-jgit on a directory that has uncommitted changes (see details above).
[ERROR] Either commit all changes/add files to .gitignore, or enable fallback to default timestamp provider by configuring
[ERROR] jgit.dirtyWorkingTree=warning for tycho-packaging-plugin
`````