### PR TITLE
Use JUnit5 instead of JUnit3 with maven-surefire-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,13 @@
 						</goals>
 					</execution>
 				</executions>
+				<dependencies>
+					<dependency>
+						<groupId>org.junit.jupiter</groupId>
+						<artifactId>junit-jupiter-engine</artifactId>
+						<version>5.8.2</version>
+					</dependency>
+				</dependencies>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -297,5 +304,4 @@
 			</snapshots>
 		</pluginRepository>
 	</pluginRepositories>
-
 </project>


### PR DESCRIPTION
Currently model unit tests in `org.eclipse.tm4e.core` and `org.eclipse.tm4e.languageconfiguration` are executed with the wrong autodetected **JUnit3Provider** by maven-surefire-plugin. E.g.
```
[INFO] --- maven-surefire-plugin:3.0.0-M6:test (default-test) @ org.eclipse.tm4e.core ---
[INFO] Using auto detected provider org.apache.maven.surefire.junit.JUnit3Provider
```

This PR ensures the `maven-surefire-plugin` tests using the JUnit5 [JUnitPlatformProvider](https://maven.apache.org/surefire/surefire-providers/surefire-junit-platform/apidocs/org/apache/maven/surefire/junitplatform/JUnitPlatformProvider.html):
```
[INFO] --- maven-surefire-plugin:3.0.0-M6:test (default-test) @ org.eclipse.tm4e.core ---
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
```