### PR TITLE
Make gson dependency non-optional

### DIFF
--- a/org.eclipse.tm4e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.core/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-SymbolicName: org.eclipse.tm4e.core
 Bundle-Version: 0.4.4.qualifier
 Require-Bundle: org.apache.batik.css;bundle-version="1.9.1";resolution:=optional,
  org.apache.batik.util;bundle-version="1.9.1";resolution:=optional,
- com.google.gson;resolution:=optional,
+ com.google.gson,
  com.google.guava;bundle-version="30.1.0",
  org.jcodings;bundle-version="1.0.57",
  org.joni;bundle-version="2.1.43",


### PR DESCRIPTION
The gson-base JSON parser is not implemented or referenced in a dynamic/optional way but is hard referenced in the code at in the [GrammarReader](https://github.com/eclipse/tm4e/blob/5a3c7ba072c3ee6988425e8b6ca5ba3e67cfde7e/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/reader/GrammarReader.java#L80). Thus gson is not an optional dependency.