### PR TITLE
Add error handling when loading language configs for unknown content types

### DIFF
--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/ILanguageConfigurationRegistryManager.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/ILanguageConfigurationRegistryManager.java
@@ -67,6 +67,5 @@ public interface ILanguageConfigurationRegistryManager {
 	 *         null otherwise.
 	 */
 	@Nullable
-	ILanguageConfiguration getLanguageConfigurationFor(IContentType[] contentTypes);
-
+	ILanguageConfiguration getLanguageConfigurationFor(IContentType... contentTypes);
 }

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/ToggleLineCommentHandler.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/ToggleLineCommentHandler.java
@@ -76,9 +76,11 @@ public class ToggleLineCommentHandler extends AbstractHandler {
 			return null;
 		}
 
-		ContentTypeInfo info;
+		final ContentTypeInfo info;
 		try {
 			info = ContentTypeHelper.findContentTypes(document);
+			if (info == null)
+				return null;
 		} catch (final CoreException e) {
 			return null;
 		}

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/AbstractLanguageConfigurationRegistryManager.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/AbstractLanguageConfigurationRegistryManager.java
@@ -55,7 +55,7 @@ public abstract class AbstractLanguageConfigurationRegistryManager implements IL
 
 	@Nullable
 	@Override
-	public ILanguageConfiguration getLanguageConfigurationFor(final IContentType[] contentTypes) {
+	public ILanguageConfiguration getLanguageConfigurationFor(final IContentType... contentTypes) {
 		for (final IContentType contentType : contentTypes) {
 			if (userDefinitions.containsKey(contentType)) {
 				return userDefinitions.get(contentType).getLanguageConfiguration();

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/LanguageConfigurationDefinition.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/LanguageConfigurationDefinition.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -54,9 +55,15 @@ public final class LanguageConfigurationDefinition extends TMResource implements
 		this.contentType = contentType;
 	}
 
-	public LanguageConfigurationDefinition(final IConfigurationElement ce) {
+	public LanguageConfigurationDefinition(final IConfigurationElement ce) throws CoreException {
 		super(ce);
-		this.contentType = ContentTypeHelper.getContentTypeById(ce.getAttribute(XMLConstants.CONTENT_TYPE_ID_ATTR));
+		final var contentTypeId = ce.getAttribute(XMLConstants.CONTENT_TYPE_ID_ATTR);
+		final var contentType = ContentTypeHelper.getContentTypeById(contentTypeId);
+		if (contentType == null)
+			throw new CoreException(
+					new Status(IStatus.ERROR, LanguageConfiguration.class,
+							"Cannot load language configuration with unknown content type ID " + contentTypeId));
+		this.contentType = contentType;
 	}
 
 	/**

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/LanguageConfigurationPlugin.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/LanguageConfigurationPlugin.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.tm4e.languageconfiguration.internal;
 
+import org.eclipse.core.runtime.IStatus;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
@@ -30,6 +31,13 @@ public final class LanguageConfigurationPlugin extends AbstractUIPlugin {
 	@Nullable
 	static LanguageConfigurationPlugin getInstance() {
 		return INSTANCE;
+	}
+
+	public static void log(IStatus status) {
+		final var plugin = LanguageConfigurationPlugin.INSTANCE;
+		if (plugin != null) {
+			plugin.getLog().log(status);
+		}
 	}
 
 	@Override

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/LanguageConfigurationRegistryManager.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/LanguageConfigurationRegistryManager.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.content.IContentType;
 import org.eclipse.core.runtime.preferences.InstanceScope;
@@ -67,8 +68,9 @@ public final class LanguageConfigurationRegistryManager extends AbstractLanguage
 		for (final var iDefinition : getDefinitions()) {
 			if (iDefinition instanceof LanguageConfigurationDefinition) {
 				final var definition = (LanguageConfigurationDefinition) iDefinition;
-				if (contentType.isKindOf(definition.getContentType())
-						&& (bestFit == null || definition.getContentType().isKindOf(bestFit.getContentType()))) {
+				final var definitionContentType = definition.getContentType();
+				if (contentType.isKindOf(definitionContentType)
+						&& (bestFit == null || definitionContentType.isKindOf(bestFit.getContentType()))) {
 					bestFit = definition;
 				}
 			}
@@ -253,7 +255,13 @@ public final class LanguageConfigurationRegistryManager extends AbstractLanguage
 		for (final var configElem : config) {
 			final String name = configElem.getName();
 			if (LANGUAGE_CONFIGURATION_ELT.equals(name)) {
-				final LanguageConfigurationDefinition delegate = new LanguageConfigurationDefinition(configElem);
+				final LanguageConfigurationDefinition delegate;
+				try {
+					delegate = new LanguageConfigurationDefinition(configElem);
+				} catch (CoreException ex) {
+					LanguageConfigurationPlugin.log(ex.getStatus());
+					continue;
+				}
 				registerLanguageConfigurationDefinition(delegate);
 			}
 		}

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/wizards/SelectLanguageConfigurationWizardPage.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/wizards/SelectLanguageConfigurationWizardPage.java
@@ -312,7 +312,7 @@ final class SelectLanguageConfigurationWizardPage extends WizardPage implements 
 			return new Status(IStatus.ERROR, LanguageConfigurationPlugin.PLUGIN_ID,
 					SelectLanguageConfigurationWizardPage_contentTypeError_invalid);
 		}
-		if (registryManager.getLanguageConfigurationFor(new IContentType[] { contentType }) != null) {
+		if (registryManager.getLanguageConfigurationFor(contentType) != null) {
 			return new Status(IStatus.WARNING, LanguageConfigurationPlugin.PLUGIN_ID,
 					SelectLanguageConfigurationWizardPage_contentTypeWarning_duplicate);
 		}

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/wizards/SelectLanguageConfigurationWizardPage.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/wizards/SelectLanguageConfigurationWizardPage.java
@@ -302,8 +302,7 @@ final class SelectLanguageConfigurationWizardPage extends WizardPage implements 
 		}
 
 		final var contentTypeText = this.contentTypeText;
-		assert contentTypeText != null;
-		if (contentTypeText.getText().isEmpty()) {
+		if (contentTypeText == null || contentTypeText.getText().isEmpty()) {
 			return new Status(IStatus.ERROR, LanguageConfigurationPlugin.PLUGIN_ID,
 					SelectLanguageConfigurationWizardPage_contentTypeError_noSelection);
 		}
@@ -320,17 +319,15 @@ final class SelectLanguageConfigurationWizardPage extends WizardPage implements 
 	}
 
 	ILanguageConfigurationDefinition getDefinition() {
-		final var fileText = this.fileText;
 		assert fileText != null;
 		IPath path = new Path(fileText.getText());
 		if (!path.isAbsolute()) {
 			path = ResourcesPlugin.getWorkspace().getRoot().getFile(path).getLocation();
 		}
 
-		final var contentTypeText = this.contentTypeText;
 		assert contentTypeText != null;
-		return new LanguageConfigurationDefinition(
-				ContentTypeHelper.getContentTypeById(contentTypeText.getText()),
-				path.toString());
+		final var contentType = ContentTypeHelper.getContentTypeById(contentTypeText.getText());
+		assert contentType != null;
+		return new LanguageConfigurationDefinition(contentType, path.toString());
 	}
 }

--- a/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/TMResource.java
+++ b/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/TMResource.java
@@ -55,7 +55,7 @@ public class TMResource implements ITMResource {
 		this.pluginId = ce.getNamespaceIdentifier();
 	}
 
-	public TMResource(final String path, final String pluginId) {
+	public TMResource(@Nullable final String path, @Nullable final String pluginId) {
 		this.path = path;
 		this.pluginId = pluginId;
 	}

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/preferences/GrammarPreferencePage.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/preferences/GrammarPreferencePage.java
@@ -306,7 +306,8 @@ public final class GrammarPreferencePage extends PreferencePage implements IWork
 				if (selectedAssociation != null) {
 					setPreviewTheme(selectedAssociation.getThemeId());
 				}
-				castNonNull(previewViewer).setGrammar(grammar);
+				final var previewViewer = castNonNull(GrammarPreferencePage.this.previewViewer);
+				previewViewer.setGrammar(grammar);
 
 				// Snippet
 				final ISnippet[] snippets = snippetManager.getSnippets(scopeName);
@@ -314,10 +315,9 @@ public final class GrammarPreferencePage extends PreferencePage implements IWork
 					previewViewer.setText("");
 				} else {
 					// TODO: manage list of snippet for the given scope.
-				   castNonNull(previewViewer).setText(snippets[0].getContent());
+				   previewViewer.setText(snippets[0].getContent());
 				}
 			}
-
 		});
 
 		// Specify default sorting

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/utils/ContentTypeHelper.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/utils/ContentTypeHelper.java
@@ -67,6 +67,7 @@ public final class ContentTypeHelper {
 	 * @param contentTypeId
 	 * @return matching content type or null
 	 */
+	@Nullable
 	public static IContentType getContentTypeById(final String contentTypeId) {
 		final IContentTypeManager manager = Platform.getContentTypeManager();
 		return manager.getContentType(contentTypeId);


### PR DESCRIPTION
Language configurations that reference content types unknown to the current Eclipse installation are now skipped during load and an error will be logged.
Without this change the `LanguageConfiguration` instances will be created with 'contentType` being `null`. This leads to various issues (e.g. the complete `Preferences > Text Mate > Language Configuration` config page will fail to load) as the code base expects this never to be the case.