### PR TITLE
use var keyword where new objects are assigned to local variables

### DIFF
--- a/org.eclipse.tm4e.core.tests/src/main/java/org/eclipse/tm4e/core/grammar/internal/RawTestImpl.java
+++ b/org.eclipse.tm4e.core.tests/src/main/java/org/eclipse/tm4e/core/grammar/internal/RawTestImpl.java
@@ -91,7 +91,7 @@ public class RawTestImpl {
 			}
 		};
 
-		final Registry registry = new Registry(options);
+		final var registry = new Registry(options);
 		IGrammar grammar = getGrammar(registry, testLocation.getParentFile());
 		if (getGrammarScopeName() != null) {
 			grammar = registry.grammarForScopeName(getGrammarScopeName());

--- a/org.eclipse.tm4e.core.tests/src/main/java/org/eclipse/tm4e/core/internal/theme/ThemeMatchingTest.java
+++ b/org.eclipse.tm4e.core.tests/src/main/java/org/eclipse/tm4e/core/internal/theme/ThemeMatchingTest.java
@@ -97,8 +97,8 @@ class ThemeMatchingTest {
 		"}");
 
 
-		final ScopeListElement root = new ScopeListElement(null, "text.html.cshtml", 0);
-		final ScopeListElement parent = new ScopeListElement(root, "meta.tag.structure.any.html", 0);
+		final var root = new ScopeListElement(null, "text.html.cshtml", 0);
+		final var parent = new ScopeListElement(root, "meta.tag.structure.any.html", 0);
 		final int r = ScopeListElement.mergeMetadata(0, parent, new ScopeMetadata("entity.name.tag.structure.any.html", 0, 0,
 				theme.match("entity.name.tag.structure.any.html")));
 		final String color = theme.getColor(StackElementMetadata.getForeground(r));
@@ -238,9 +238,9 @@ class ThemeMatchingTest {
 			new ThemeTrieElementRule(0, null, FontStyle.NotSet, _NOT_SET, _NOT_SET)
 		});
 
-		final ScopeListElement parent3 = new ScopeListElement(null, "source.json", 0);
-		final ScopeListElement parent2 = new ScopeListElement(parent3, "meta.structure.dictionary.json", 0);
-		final ScopeListElement parent1 = new ScopeListElement(parent2, "meta.structure.dictionary.value.json", 0);
+		final var parent3 = new ScopeListElement(null, "source.json", 0);
+		final var parent2 = new ScopeListElement(parent3, "meta.structure.dictionary.json", 0);
+		final var parent1 = new ScopeListElement(parent2, "meta.structure.dictionary.value.json", 0);
 
 		final int r = ScopeListElement.mergeMetadata(
 			0,

--- a/org.eclipse.tm4e.core.tests/src/main/java/org/eclipse/tm4e/core/internal/theme/ThemeResolvingTest.java
+++ b/org.eclipse.tm4e.core.tests/src/main/java/org/eclipse/tm4e/core/internal/theme/ThemeResolvingTest.java
@@ -140,7 +140,7 @@ public class ThemeResolvingTest {
 		final var colorMap = new ColorMap();
 		final int _A = colorMap.getId("#000000");
 		final int _B = colorMap.getId("#ffffff");
-		final Theme expected = new Theme(colorMap,
+		final var expected = new Theme(colorMap,
 				new ThemeTrieElementRule(0, null, FontStyle.None, _A, _B), NOTSET_THEME_TRIE_ELEMENT);
 		assertEquals(actual, expected);
 	}
@@ -208,7 +208,7 @@ public class ThemeResolvingTest {
 		final var map = new HashMap<String, ThemeTrieElement>();
 		map.put("var", new ThemeTrieElement(new ThemeTrieElementRule(1, null, FontStyle.NotSet, _C, NOT_SET)));
 
-		final Theme expected = new Theme(colorMap,
+		final var expected = new Theme(colorMap,
 				new ThemeTrieElementRule(0, null, FontStyle.None, _A, _B),
 				new ThemeTrieElement(NOTSET_THEME_TRIE_ELEMENT_RULE, Collections.emptyList(), map));
 		assertEquals(actual, expected);

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/Grammar.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/Grammar.java
@@ -299,7 +299,7 @@ public final class Grammar implements IGrammar, IRuleFactoryHelper {
 			final var rawRootMetadata = this.scopeMetadataProvider.getMetadataForScope(rootScopeName);
 			final int rootMetadata = ScopeListElement.mergeMetadata(defaultMetadata, null, rawRootMetadata);
 
-			final ScopeListElement scopeList = new ScopeListElement(null,
+			final var scopeList = new ScopeListElement(null,
 					rootScopeName == null ? "unknown" : rootScopeName, rootMetadata);
 
 			prevState = new StackElement(null, this.rootId, -1, -1, false, null, scopeList, scopeList);

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/LineTokenizer.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/LineTokenizer.java
@@ -502,7 +502,7 @@ final class LineTokenizer {
 	private WhileCheckResult checkWhileConditions(final Grammar grammar, final OnigString lineText, boolean isFirstLine,
 			int linePos, StackElement stack, final LineTokens lineTokens) {
 		int currentanchorPosition = stack.beginRuleCapturedEOL ? 0 : -1;
-		final List<WhileStack> whileRules = new ArrayList<>();
+		final var whileRules = new ArrayList<WhileStack>();
 		for (StackElement node = stack; node != null; node = node.pop()) {
 			final Rule nodeRule = node.getRule(grammar);
 			if (nodeRule instanceof final BeginWhileRule beginWhileRule) {

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/RawRule.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/RawRule.java
@@ -95,9 +95,9 @@ public class RawRule extends HashMap<String, @Nullable Object>
 	private void updateCaptures(final String name) {
 		final Object captures = get(name);
 		if (captures instanceof final List<?> capturesList) {
-			final RawRule rawCaptures = new RawRule();
+			final var rawCaptures = new RawRule();
 			int i = 0;
-			for (final Object capture : capturesList) {
+			for (final var capture : capturesList) {
 				i++;
 				rawCaptures.put(Integer.toString(i), capture);
 			}

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/ScopeListElement.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/ScopeListElement.java
@@ -109,7 +109,7 @@ public final class ScopeListElement {
 		}
 
 		parent_scopes_loop: for (final String selector : parentScopes) {
-			final String selectorWithDot = selector + '.';
+			final var selectorWithDot = selector + '.';
 
 			while (target != null) {
 				if (matchesScope(target.scope, selector, selectorWithDot)) {

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/theme/Theme.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/theme/Theme.java
@@ -93,7 +93,7 @@ public class Theme {
 			return Collections.emptyList();
 		}
 
-		final List<ParsedThemeRule> result = new ArrayList<>();
+		final var result = new ArrayList<ParsedThemeRule>();
 		int i = -1;
 		for (final IRawThemeSetting entry : settings) {
 			final var entrySetting = entry.getSetting();

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/types/IRawRepository.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/types/IRawRepository.java
@@ -23,7 +23,7 @@ import org.eclipse.tm4e.core.internal.parser.PropertySettable;
 public interface IRawRepository {
 
 	static IRawRepository merge(@Nullable final IRawRepository... sources) {
-		final RawRepository merged = new RawRepository();
+		final var merged = new RawRepository();
 		for (final var source : sources) {
 			if (source == null)
 				continue;

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/registry/Registry.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/registry/Registry.java
@@ -73,10 +73,10 @@ public class Registry {
 
 	@Nullable
 	public IGrammar loadGrammar(final String initialScopeName) {
-		final List<String> remainingScopeNames = new ArrayList<>();
+		final var remainingScopeNames = new ArrayList<String>();
 		remainingScopeNames.add(initialScopeName);
 
-		final List<String> seenScopeNames = new ArrayList<>();
+		final var seenScopeNames = new ArrayList<String>();
 		seenScopeNames.add(initialScopeName);
 
 		while (!remainingScopeNames.isEmpty()) {

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/theme/css/CSSParser.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/theme/css/CSSParser.java
@@ -43,7 +43,7 @@ public class CSSParser {
 	}
 
 	private static InputSource toSource(final InputStream source) {
-		final InputSource in = new InputSource();
+		final var in = new InputSource();
 		in.setByteStream(source);
 		return in;
 	}

--- a/org.eclipse.tm4e.core/src/test/java/org/eclipse/tm4e/core/TestGrammar.java
+++ b/org.eclipse.tm4e.core/src/test/java/org/eclipse/tm4e/core/TestGrammar.java
@@ -21,7 +21,7 @@ public class TestGrammar {
 
 	public static void main(final String[] args) throws Exception {
 
-		final Registry registry = new Registry();
+		final var registry = new Registry();
 		final IGrammar grammar = castNonNull(registry.loadGrammarFromPathSync("Angular2TypeScript.tmLanguage",
 				TestGrammar.class.getResourceAsStream("Angular2TypeScript.tmLanguage")));
 

--- a/org.eclipse.tm4e.core/src/test/java/org/eclipse/tm4e/core/grammar/GrammarInjectionTest.java
+++ b/org.eclipse.tm4e.core/src/test/java/org/eclipse/tm4e/core/grammar/GrammarInjectionTest.java
@@ -31,59 +31,58 @@ import org.junit.jupiter.api.Test;
  */
 public class GrammarInjectionTest {
 
-	private static final String[] EXPECTED_TOKENS = {
-			"Token from 0 to 1 with scopes [source.ts, meta.decorator.ts, punctuation.decorator.ts]",
-			"Token from 1 to 10 with scopes [source.ts, meta.decorator.ts, entity.name.function.ts]",
-			"Token from 10 to 11 with scopes [source.ts, meta.decorator.ts, meta.brace.round.ts]",
-			"Token from 11 to 12 with scopes [source.ts, meta.decorator.ts, meta.object-literal.ts, punctuation.definition.block.ts]",
-			"Token from 12 to 20 with scopes [source.ts, meta.decorator.ts, meta.object-literal.ts, meta.object.member.ts, meta.object-literal.key.ts]",
-			"Token from 20 to 21 with scopes [source.ts, meta.decorator.ts, meta.object-literal.ts, meta.object.member.ts, meta.object-literal.key.ts, punctuation.separator.key-value.ts]",
-			"Token from 21 to 22 with scopes [source.ts, meta.decorator.ts, meta.object-literal.ts, meta.object.member.ts, string.template.ts, punctuation.definition.string.template.begin.ts]",
-			"Token from 22 to 38 with scopes [source.ts, meta.decorator.ts, meta.object-literal.ts, meta.object.member.ts, string.template.ts]",
-			"Token from 38 to 39 with scopes [source.ts, meta.decorator.ts, meta.object-literal.ts, meta.object.member.ts, string.template.ts, punctuation.definition.string.template.end.ts]",
-			"Token from 39 to 40 with scopes [source.ts, meta.decorator.ts, meta.object-literal.ts, punctuation.definition.block.ts]",
-			"Token from 40 to 41 with scopes [source.ts, meta.decorator.ts, meta.brace.round.ts]" };
+   private static final String[] EXPECTED_TOKENS = {
+      "Token from 0 to 1 with scopes [source.ts, meta.decorator.ts, punctuation.decorator.ts]",
+      "Token from 1 to 10 with scopes [source.ts, meta.decorator.ts, entity.name.function.ts]",
+      "Token from 10 to 11 with scopes [source.ts, meta.decorator.ts, meta.brace.round.ts]",
+      "Token from 11 to 12 with scopes [source.ts, meta.decorator.ts, meta.object-literal.ts, punctuation.definition.block.ts]",
+      "Token from 12 to 20 with scopes [source.ts, meta.decorator.ts, meta.object-literal.ts, meta.object.member.ts, meta.object-literal.key.ts]",
+      "Token from 20 to 21 with scopes [source.ts, meta.decorator.ts, meta.object-literal.ts, meta.object.member.ts, meta.object-literal.key.ts, punctuation.separator.key-value.ts]",
+      "Token from 21 to 22 with scopes [source.ts, meta.decorator.ts, meta.object-literal.ts, meta.object.member.ts, string.template.ts, punctuation.definition.string.template.begin.ts]",
+      "Token from 22 to 38 with scopes [source.ts, meta.decorator.ts, meta.object-literal.ts, meta.object.member.ts, string.template.ts]",
+      "Token from 38 to 39 with scopes [source.ts, meta.decorator.ts, meta.object-literal.ts, meta.object.member.ts, string.template.ts, punctuation.definition.string.template.end.ts]",
+      "Token from 39 to 40 with scopes [source.ts, meta.decorator.ts, meta.object-literal.ts, punctuation.definition.block.ts]",
+      "Token from 40 to 41 with scopes [source.ts, meta.decorator.ts, meta.brace.round.ts]"};
 
-	@Test
-	public void angular2TokenizeLine() throws Exception {
-		final Registry registry = new Registry(new IRegistryOptions() {
+   @Test
+   public void angular2TokenizeLine() throws Exception {
+      final var registry = new Registry(new IRegistryOptions() {
 
-			@Nullable
-			@Override
-			public InputStream getInputStream(@Nullable final String scopeName) throws IOException {
-				return Data.class.getResourceAsStream(getFilePath(scopeName));
-			}
+         @Nullable
+         @Override
+         public InputStream getInputStream(@Nullable final String scopeName) throws IOException {
+            return Data.class.getResourceAsStream(getFilePath(scopeName));
+         }
 
-			@Nullable
-			@Override
-			public Collection<String> getInjections(@Nullable final String scopeName) {
-				return List.of("template.ng", "styles.ng");
-			}
+         @Nullable
+         @Override
+         public Collection<String> getInjections(@Nullable final String scopeName) {
+            return List.of("template.ng", "styles.ng");
+         }
 
-			@Nullable
-			@Override
-			public String getFilePath(@Nullable final String scopeName) {
-				if (scopeName != null) {
-					return switch (scopeName) {
-					case "source.js" -> "JavaScript.tmLanguage.json";
-					case "text.html.basic" -> "html.json";
-					case "source.ts" -> "TypeScript.tmLanguage.json";
-					case "template.ng" -> "template.ng.json";
-					case "styles.ng" -> "styles.ng.json";
-					default -> null;
-					};
-				}
-				return null;
-			}
-		});
-		final IGrammar grammar = registry.loadGrammar("source.ts");
-		final var lineTokens = castNonNull(grammar).tokenizeLine("@Component({template:`<a href='' ></a>`})");
-		for (int i = 0; i < lineTokens.getTokens().length; i++) {
-			final IToken token = lineTokens.getTokens()[i];
-			final String s = "Token from " + token.getStartIndex() + " to " + token.getEndIndex() + " with scopes "
-					+ token.getScopes();
-			System.err.println(s);
-			Assertions.assertEquals(EXPECTED_TOKENS[i], s);
-		}
-	}
+         @Nullable
+         @Override
+         public String getFilePath(@Nullable final String scopeName) {
+            if (scopeName != null) {
+               return switch (scopeName) {
+                  case "source.js" -> "JavaScript.tmLanguage.json";
+                  case "text.html.basic" -> "html.json";
+                  case "source.ts" -> "TypeScript.tmLanguage.json";
+                  case "template.ng" -> "template.ng.json";
+                  case "styles.ng" -> "styles.ng.json";
+                  default -> null;
+               };
+            }
+            return null;
+         }
+      });
+      final IGrammar grammar = registry.loadGrammar("source.ts");
+      final var lineTokens = castNonNull(grammar).tokenizeLine("@Component({template:`<a href='' ></a>`})");
+      for (int i = 0; i < lineTokens.getTokens().length; i++) {
+         final IToken token = lineTokens.getTokens()[i];
+         final var s = "Token from " + token.getStartIndex() + " to " + token.getEndIndex() + " with scopes " + token.getScopes();
+         System.err.println(s);
+         Assertions.assertEquals(EXPECTED_TOKENS[i], s);
+      }
+   }
 }

--- a/org.eclipse.tm4e.core/src/test/java/org/eclipse/tm4e/core/grammar/GrammarTest.java
+++ b/org.eclipse.tm4e.core/src/test/java/org/eclipse/tm4e/core/grammar/GrammarTest.java
@@ -61,8 +61,8 @@ public class GrammarTest {
 
 	@Test
 	public void tokenizeLine() throws Exception {
-		final Registry registry = new Registry();
-		final String path = "JavaScript.tmLanguage";
+		final var registry = new Registry();
+		final var path = "JavaScript.tmLanguage";
 		final IGrammar grammar = registry.loadGrammarFromPathSync(path, Data.class.getResourceAsStream(path));
 		final ITokenizeLineResult lineTokens = castNonNull(grammar).tokenizeLine("function add(a,b) { return a+b; }");
 		for (int i = 0; i < lineTokens.getTokens().length; i++) {
@@ -75,8 +75,8 @@ public class GrammarTest {
 
 	@Test
 	public void tokenizeLines() throws Exception {
-		final Registry registry = new Registry();
-		final String path = "JavaScript.tmLanguage";
+		final var registry = new Registry();
+		final var path = "JavaScript.tmLanguage";
 		final IGrammar grammar = registry.loadGrammarFromPathSync(path, Data.class.getResourceAsStream(path));
 
 		IStackElement ruleStack = null;

--- a/org.eclipse.tm4e.core/src/test/java/org/eclipse/tm4e/core/grammar/GrammarTest2.java
+++ b/org.eclipse.tm4e.core/src/test/java/org/eclipse/tm4e/core/grammar/GrammarTest2.java
@@ -29,62 +29,58 @@ import org.junit.jupiter.api.Test;
  */
 class GrammarTest2 {
 
-	@Test
-	void tokenizeLines() throws Exception {
-		final var registry = new Registry();
-		final var path = "JavaScript.tmLanguage";
-		try (var is = Data.class.getResourceAsStream(path)) {
-			final var grammar = castNonNull(registry.loadGrammarFromPathSync(path, is));
+   @Test
+   void tokenizeLines() throws Exception {
+      final var registry = new Registry();
+      final var path = "JavaScript.tmLanguage";
+      try (var is = Data.class.getResourceAsStream(path)) {
+         final var grammar = castNonNull(registry.loadGrammarFromPathSync(path, is));
 
-			IStackElement ruleStack = null;
-			int i = 0;
+         IStackElement ruleStack = null;
+         int i = 0;
 
-			final var lines = new ArrayList<String>();
-			try (var reader = new BufferedReader(
-					new InputStreamReader(Data.class.getResourceAsStream("raytracer.ts")));) {
-				String line = null;
-				while ((line = reader.readLine()) != null) {
-					lines.add(line);
-				}
-			}
+         final var lines = new ArrayList<String>();
+         try (var reader = new BufferedReader(new InputStreamReader(Data.class.getResourceAsStream("raytracer.ts")));) {
+            String line = null;
+            while ((line = reader.readLine()) != null) {
+               lines.add(line);
+            }
+         }
 
-			int t = 0;
-			boolean stop = false;
-			final long start = System.currentTimeMillis();
-			for (final String line : lines) {
-				final ITokenizeLineResult lineTokens = grammar.tokenizeLine(line, ruleStack);
-				if (stop) {
-					t = 1000;
-					Thread.sleep(t);
-					stop = false;
-				}
-				ruleStack = lineTokens.getRuleStack();
-				for (i = 0; i < lineTokens.getTokens().length; i++) {
-					final IToken token = lineTokens.getTokens()[i];
-					final String s = "Token from " + token.getStartIndex() + " to " + token.getEndIndex() + " with scopes "
-							+ token.getScopes();
-					// System.err.println(s);
-					// Assert.assertEquals(EXPECTED_MULTI_LINE_TOKENS[i + j], s);
-				}
-			}
-			System.out.println(System.currentTimeMillis() - start - t);
-		}
-	}
+         int t = 0;
+         boolean stop = false;
+         final long start = System.currentTimeMillis();
+         for (final String line : lines) {
+            final ITokenizeLineResult lineTokens = grammar.tokenizeLine(line, ruleStack);
+            if (stop) {
+               t = 1000;
+               Thread.sleep(t);
+               stop = false;
+            }
+            ruleStack = lineTokens.getRuleStack();
+            for (i = 0; i < lineTokens.getTokens().length; i++) {
+               final IToken token = lineTokens.getTokens()[i];
+               final var s = "Token from " + token.getStartIndex() + " to " + token.getEndIndex() + " with scopes " + token.getScopes();
+               // System.err.println(s);
+               // Assert.assertEquals(EXPECTED_MULTI_LINE_TOKENS[i + j], s);
+            }
+         }
+         System.out.println(System.currentTimeMillis() - start - t);
+      }
+   }
 
-	@Test
-	public void testYamlMultiline() throws Exception {
-		final var registry = new Registry();
-		final var path = "yaml.tmLanguage.json";
-		try (var in = Data.class.getResourceAsStream(path)) {
-			final var grammar = castNonNull(registry.loadGrammarFromPathSync(path, in));
-			final String lines = ">\n should.be.string.unquoted.block.yaml\n should.also.be.string.unquoted.block.yaml";
-			final var result = TokenizationUtils.tokenizeText(lines, grammar).iterator();
-			assertTrue(Arrays.stream(result.next().getTokens())
-					.anyMatch(t -> t.getScopes().contains("keyword.control.flow.block-scalar.folded.yaml")));
-			assertTrue(Arrays.stream(result.next().getTokens())
-					.anyMatch(t -> t.getScopes().contains("string.unquoted.block.yaml")));
-			assertTrue(Arrays.stream(result.next().getTokens())
-					.anyMatch(t -> t.getScopes().contains("string.unquoted.block.yaml")));
-		}
-	}
+   @Test
+   public void testYamlMultiline() throws Exception {
+      final var registry = new Registry();
+      final var path = "yaml.tmLanguage.json";
+      try (var in = Data.class.getResourceAsStream(path)) {
+         final var grammar = castNonNull(registry.loadGrammarFromPathSync(path, in));
+         final var lines = ">\n should.be.string.unquoted.block.yaml\n should.also.be.string.unquoted.block.yaml";
+         final var result = TokenizationUtils.tokenizeText(lines, grammar).iterator();
+         assertTrue(Arrays.stream(result.next().getTokens()).anyMatch(t -> t.getScopes().contains(
+            "keyword.control.flow.block-scalar.folded.yaml")));
+         assertTrue(Arrays.stream(result.next().getTokens()).anyMatch(t -> t.getScopes().contains("string.unquoted.block.yaml")));
+         assertTrue(Arrays.stream(result.next().getTokens()).anyMatch(t -> t.getScopes().contains("string.unquoted.block.yaml")));
+      }
+   }
 }

--- a/org.eclipse.tm4e.core/src/test/java/org/eclipse/tm4e/core/grammar/MarkDown.java
+++ b/org.eclipse.tm4e.core/src/test/java/org/eclipse/tm4e/core/grammar/MarkDown.java
@@ -24,12 +24,12 @@ import org.eclipse.tm4e.core.registry.Registry;
 public class MarkDown {
 
 	public static void main(final String[] args) throws Exception {
-		final Registry registry = new Registry();
-		final String path = "Markdown.tmLanguage";
+		final var registry = new Registry();
+		final var path = "Markdown.tmLanguage";
 		final IGrammar grammar = castNonNull(registry.loadGrammarFromPathSync(path, Data.class.getResourceAsStream(path)));
 
-		final List<String> lines = new ArrayList<>();
-		try (BufferedReader reader = new BufferedReader(new InputStreamReader(Data.class.getResourceAsStream("test.md.txt")))) {
+		final var lines = new ArrayList<String>();
+		try (var reader = new BufferedReader(new InputStreamReader(Data.class.getResourceAsStream("test.md.txt")))) {
 			String line = null;
 			while ((line = reader.readLine()) != null) {
 				lines.add(line);
@@ -58,7 +58,7 @@ public class MarkDown {
 	}
 
 	static String convertStreamToString(final java.io.InputStream is) {
-	    try (java.util.Scanner s = new java.util.Scanner(is).useDelimiter("\\A")) {
+	    try (var s = new java.util.Scanner(is).useDelimiter("\\A")) {
 	    	return s.hasNext() ? s.next() : "";
 	    }
 	}

--- a/org.eclipse.tm4e.core/src/test/java/org/eclipse/tm4e/core/internal/grammar/StackElementMetadataTest.java
+++ b/org.eclipse.tm4e.core/src/test/java/org/eclipse/tm4e/core/internal/grammar/StackElementMetadataTest.java
@@ -100,7 +100,7 @@ public class StackElementMetadataTest {
 
 	private static void assertEquals(final int metadata, final int languageId, final int /*StandardTokenType*/ tokenType,
 			final boolean containsBalancedBrackets, final int /*FontStyle*/ fontStyle, final int foreground, final int background) {
-		final String actual = "{\n" +
+		final var actual = "{\n" +
 				"languageId: " + StackElementMetadata.getLanguageId(metadata) + ",\n" +
 				"tokenType: " + StackElementMetadata.getTokenType(metadata) + ",\n" +
 				"containsBalancedBrackets: " + StackElementMetadata.containsBalancedBrackets(metadata) + ",\n" +
@@ -109,7 +109,7 @@ public class StackElementMetadataTest {
 				"background: " + StackElementMetadata.getBackground(metadata) + ",\n" +
 				"}";
 
-		final String expected = "{\n" +
+		final var expected = "{\n" +
 				"languageId: " + languageId + ",\n" +
 				"tokenType: " + tokenType + ",\n" +
 				"containsBalancedBrackets: " + containsBalancedBrackets + ",\n" +

--- a/org.eclipse.tm4e.core/src/test/java/org/eclipse/tm4e/core/internal/oniguruma/OnigScannerTest.java
+++ b/org.eclipse.tm4e.core/src/test/java/org/eclipse/tm4e/core/internal/oniguruma/OnigScannerTest.java
@@ -21,7 +21,7 @@ class OnigScannerTest {
 
 	@Test
 	void testOnigScanner() {
-		OnigScanner scanner = new OnigScanner(Arrays.asList("c", "a(b)?"));
+		var scanner = new OnigScanner(Arrays.asList("c", "a(b)?"));
 		OnigNextMatchResult result = scanner.findNextMatchSync("abc", 0);
 		assertNotNull(result);
 		assertEquals(1, result.getIndex());

--- a/org.eclipse.tm4e.core/src/test/java/org/eclipse/tm4e/core/internal/oniguruma/OnigStringTest.java
+++ b/org.eclipse.tm4e.core/src/test/java/org/eclipse/tm4e/core/internal/oniguruma/OnigStringTest.java
@@ -44,7 +44,7 @@ class OnigStringTest {
 
 	@Test
 	void testEmptyStrings() {
-		final String string = "";
+		final var string = "";
 		final OnigString onigString = verifyBasics(string, OnigString.SingleByteString.class);
 
 		assertEquals(0, onigString.bytesCount);
@@ -52,7 +52,7 @@ class OnigStringTest {
 
 	@Test
 	void testSingleBytesStrings() {
-		final String string = "ab";
+		final var string = "ab";
 		final OnigString onigString = verifyBasics(string, OnigString.SingleByteString.class);
 
 		assertEquals(2, onigString.bytesCount);
@@ -73,7 +73,7 @@ class OnigStringTest {
 
 	@Test
 	void testMultiByteString() {
-		final String string = "áé";
+		final var string = "áé";
 		final OnigString onigString = verifyBasics(string, OnigString.MultiByteString.class);
 
 		assertEquals(4, onigString.bytesCount);
@@ -96,7 +96,7 @@ class OnigStringTest {
 
 	@Test
 	void testMixedMultiByteString() {
-		final String string = "myááçóúôõaab";
+		final var string = "myááçóúôõaab";
 		final OnigString onigString = verifyBasics(string, OnigString.MultiByteString.class);
 
 		assertEquals(19, onigString.bytesCount);

--- a/org.eclipse.tm4e.core/src/test/java/org/eclipse/tm4e/core/internal/parser/PListParserTest.java
+++ b/org.eclipse.tm4e.core/src/test/java/org/eclipse/tm4e/core/internal/parser/PListParserTest.java
@@ -22,7 +22,7 @@ public class PListParserTest {
 
 	@Test
 	void testParseJSONPList() throws Exception {
-		final PListParser<RawGrammar> parser = new PListParserJSON<>(GrammarReader.OBJECT_FACTORY);
+		final var parser = new PListParserJSON<RawGrammar>(GrammarReader.OBJECT_FACTORY);
 		try (final var is = Data.class.getResourceAsStream("csharp.json")) {
 			final var grammar = parser.parse(is);
 			assertNotNull(grammar);
@@ -33,7 +33,7 @@ public class PListParserTest {
 
 	@Test
 	void testParseYAMLPlist() throws Exception {
-		final PListParser<RawGrammar> parser = new PListParserYAML<>(GrammarReader.OBJECT_FACTORY);
+		final var parser = new PListParserYAML<RawGrammar>(GrammarReader.OBJECT_FACTORY);
 		try (final var is = Data.class.getResourceAsStream("JavaScript.tmLanguage.yaml")) {
 			final var grammar = parser.parse(is);
 			assertNotNull(grammar);
@@ -44,7 +44,7 @@ public class PListParserTest {
 
 	@Test
 	void testParseXMLPlist() throws Exception {
-		final PListParser<RawGrammar> parser = new PListParserXML<>(GrammarReader.OBJECT_FACTORY);
+		final var parser = new PListParserXML<RawGrammar>(GrammarReader.OBJECT_FACTORY);
 		try (final var is = Data.class.getResourceAsStream("JavaScript.tmLanguage")) {
 			final var grammar = parser.parse(is);
 			assertNotNull(grammar);

--- a/org.eclipse.tm4e.core/src/test/java/org/eclipse/tm4e/core/theme/css/CSSParserTest.java
+++ b/org.eclipse.tm4e.core/src/test/java/org/eclipse/tm4e/core/theme/css/CSSParserTest.java
@@ -16,7 +16,7 @@ import org.eclipse.tm4e.core.theme.IStyle;
 public class CSSParserTest {
 
 	public static void main(final String[] args) throws Exception {
-		final CSSParser parser = new CSSParser(".comment {color:rgb(0,1,2)} .comment.ts {color:rgb(0,1,2)}");
+		final var parser = new CSSParser(".comment {color:rgb(0,1,2)} .comment.ts {color:rgb(0,1,2)}");
 		String[] names = "comment".split("[.]");
 		parser.getBestStyle(names);
 

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/ToggleLineCommentHandler.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/ToggleLineCommentHandler.java
@@ -67,12 +67,12 @@ public class ToggleLineCommentHandler extends AbstractHandler {
 			if (docProvider == null || input == null) {
 				return null;
 			}
-	
+
 			final var document = docProvider.getDocument(input);
 			if (document == null) {
 				return null;
 			}
-	
+
 			final ContentTypeInfo info;
 			try {
 				info = ContentTypeHelper.findContentTypes(document);
@@ -91,7 +91,7 @@ public class ToggleLineCommentHandler extends AbstractHandler {
 			if (!isValid(commentSupport, command)) {
 				return null;
 			}
-	
+
 			final var target = adapt(editor, IRewriteTarget.class);
 			if (target != null) {
 				target.beginCompoundChange();
@@ -109,7 +109,7 @@ public class ToggleLineCommentHandler extends AbstractHandler {
 							for (final int line : lines) {
 								final int lineOffset = document.getLineOffset(line);
 								final int lineLength = document.getLineLength(line);
-								final ITextSelection range = new TextSelection(lineOffset,
+								final var range = new TextSelection(lineOffset,
 										line == document.getNumberOfLines() - 1 ? lineLength : lineLength - 1);
 								toggleBlockComment(document, range, commentSupport, editor);
 							}
@@ -117,7 +117,7 @@ public class ToggleLineCommentHandler extends AbstractHandler {
 					}
 					break;
 				}
-	
+
 				case ADD_BLOCK_COMMENT_COMMAND_ID: {
 					final IRegion existingBlock = getBlockComment(document, textSelection, commentSupport);
 					final var blockComment = commentSupport.getBlockComment();
@@ -126,7 +126,7 @@ public class ToggleLineCommentHandler extends AbstractHandler {
 					}
 					break;
 				}
-	
+
 				case REMOVE_BLOCK_COMMENT_COMMAND_ID: {
 					final IRegion existingBlock = getBlockComment(document, textSelection, commentSupport);
 					final var blockComment = commentSupport.getBlockComment();
@@ -323,7 +323,7 @@ public class ToggleLineCommentHandler extends AbstractHandler {
 			document.replace(document.getLineOffset(lineNumber), 0, comment);
 			insertedChars += comment.length();
 		}
-		final ITextSelection newSelection = new TextSelection(selection.getOffset() + comment.length(),
+		final var newSelection = new TextSelection(selection.getOffset() + comment.length(),
 				selection.getLength() + insertedChars);
 		editor.selectAndReveal(newSelection.getOffset(), newSelection.getLength());
 	}

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/AbstractLanguageConfigurationRegistryManager.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/AbstractLanguageConfigurationRegistryManager.java
@@ -14,7 +14,6 @@ package org.eclipse.tm4e.languageconfiguration.internal;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 import org.eclipse.core.runtime.content.IContentType;
 import org.eclipse.jdt.annotation.Nullable;
@@ -29,7 +28,7 @@ public abstract class AbstractLanguageConfigurationRegistryManager implements IL
 
 	@Override
 	public ILanguageConfigurationDefinition[] getDefinitions() {
-		final Set<ILanguageConfigurationDefinition> definitions = new HashSet<>();
+		final var definitions = new HashSet<ILanguageConfigurationDefinition>();
 		userDefinitions.values().forEach(definitions::add);
 		pluginDefinitions.values().forEach(definitions::add);
 		return definitions.toArray(ILanguageConfigurationDefinition[]::new);

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/LanguageConfiguration.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/LanguageConfiguration.java
@@ -120,7 +120,7 @@ public final class LanguageConfiguration implements ILanguageConfiguration {
 						})
 				.registerTypeAdapter(AutoClosingPairConditional.class,
 						(JsonDeserializer<@Nullable AutoClosingPairConditional>) (json, typeOfT, context) -> {
-							final List<String> notInList = new ArrayList<>();
+							final var notInList = new ArrayList<String>();
 							String open = null;
 							String close = null;
 							if (json.isJsonArray()) {

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/LanguageConfigurationRegistryManager.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/LanguageConfigurationRegistryManager.java
@@ -57,7 +57,7 @@ public final class LanguageConfigurationRegistryManager extends AbstractLanguage
 		if (INSTANCE != null) {
 			return INSTANCE;
 		}
-		final LanguageConfigurationRegistryManager manager = new LanguageConfigurationRegistryManager();
+		final var manager = new LanguageConfigurationRegistryManager();
 		manager.load();
 		return manager;
 	}

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/supports/OnEnterSupport.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/supports/OnEnterSupport.java
@@ -107,8 +107,8 @@ public class OnEnterSupport {
 
 		@Nullable
 		private static Pattern createOpenBracketRegExp(final String bracket) {
-			final StringBuilder str = new StringBuilder(RegExpUtils.escapeRegExpCharacters(bracket));
-			final String c = String.valueOf(str.charAt(0));
+			final var str = new StringBuilder(RegExpUtils.escapeRegExpCharacters(bracket));
+			final var c = String.valueOf(str.charAt(0));
 			if (!B_REGEXP.matcher(c).find()) {
 				str.insert(0, "\\b"); //$NON-NLS-1$
 			}
@@ -118,8 +118,8 @@ public class OnEnterSupport {
 
 		@Nullable
 		private static Pattern createCloseBracketRegExp(final String bracket) {
-			final StringBuilder str = new StringBuilder(RegExpUtils.escapeRegExpCharacters(bracket));
-			final String c = String.valueOf(str.charAt(str.length() - 1));
+			final var str = new StringBuilder(RegExpUtils.escapeRegExpCharacters(bracket));
+			final var c = String.valueOf(str.charAt(str.length() - 1));
 			if (!B_REGEXP.matcher(c).find()) {
 				str.append("\\b"); //$NON-NLS-1$
 			}

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/utils/TextUtils.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/utils/TextUtils.java
@@ -56,7 +56,7 @@ public final class TextUtils {
 			}
 		}
 
-		final StringBuilder result = new StringBuilder();
+		final var result = new StringBuilder();
 		if (!insertSpaces) {
 			final long tabsCnt = Math.round(Math.floor(spacesCnt / tabSize));
 			spacesCnt = spacesCnt % tabSize;
@@ -106,7 +106,7 @@ public final class TextUtils {
 	}
 
 	public static String getIndentationFromWhitespace(final String whitespace, final TabSpacesInfo tabSpaces) {
-		final String tab = "\t"; //$NON-NLS-1$
+		final var tab = "\t"; //$NON-NLS-1$
 		int indentOffset = 0;
 		boolean startsWithTab = true;
 		boolean startsWithSpaces = true;

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/widgets/AutoClosingPairConditionalTableWidget.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/widgets/AutoClosingPairConditionalTableWidget.java
@@ -30,9 +30,9 @@ final class AutoClosingPairConditionalTableWidget extends CharacterPairsTableWid
 
 		final GC gc = new GC(table.getShell());
 		gc.setFont(JFaceResources.getDialogFont());
-		final TableColumnLayout columnLayout = new TableColumnLayout();
+		final var columnLayout = new TableColumnLayout();
 
-		final TableColumn column2 = new TableColumn(table, SWT.NONE);
+		final var column2 = new TableColumn(table, SWT.NONE);
 		column2.setText(LanguageConfigurationMessages.AutoClosingPairConditionalTableWidget_notIn);
 		final int minWidth = computeMinimumColumnWidth(gc,
 				LanguageConfigurationMessages.AutoClosingPairConditionalTableWidget_notIn);

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/widgets/CharacterPairsTableWidget.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/widgets/CharacterPairsTableWidget.java
@@ -40,14 +40,14 @@ class CharacterPairsTableWidget extends TableViewer {
 
 		final GC gc = new GC(table.getShell());
 		gc.setFont(JFaceResources.getDialogFont());
-		final TableColumnLayout columnLayout = new TableColumnLayout();
+		final var columnLayout = new TableColumnLayout();
 
-		final TableColumn column1 = new TableColumn(table, SWT.NONE);
+		final var column1 = new TableColumn(table, SWT.NONE);
 		column1.setText(LanguageConfigurationMessages.CharacterPairsTableWidget_start);
 		int minWidth = computeMinimumColumnWidth(gc, LanguageConfigurationMessages.CharacterPairsTableWidget_start);
 		columnLayout.setColumnData(column1, new ColumnWeightData(2, minWidth, true));
 
-		final TableColumn column2 = new TableColumn(table, SWT.NONE);
+		final var column2 = new TableColumn(table, SWT.NONE);
 		column2.setText(LanguageConfigurationMessages.CharacterPairsTableWidget_end);
 		minWidth = computeMinimumColumnWidth(gc, LanguageConfigurationMessages.CharacterPairsTableWidget_end);
 		columnLayout.setColumnData(column2, new ColumnWeightData(2, minWidth, true));

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/widgets/LanguageConfigurationInfoWidget.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/widgets/LanguageConfigurationInfoWidget.java
@@ -64,7 +64,7 @@ public class LanguageConfigurationInfoWidget extends Composite {
 
 	public LanguageConfigurationInfoWidget(final Composite parent, final int style) {
 		super(parent, style);
-		final GridLayout layout = new GridLayout();
+		final var layout = new GridLayout();
 		layout.marginHeight = 0;
 		layout.marginWidth = 0;
 		layout.marginLeft = 0;
@@ -75,9 +75,9 @@ public class LanguageConfigurationInfoWidget extends Composite {
 	}
 
 	private void createUI(final Composite ancestor) {
-		final TabFolder folder = new TabFolder(ancestor, SWT.NONE);
+		final var folder = new TabFolder(ancestor, SWT.NONE);
 
-		final GridData gd = new GridData(GridData.FILL_HORIZONTAL);
+		final var gd = new GridData(GridData.FILL_HORIZONTAL);
 		folder.setLayoutData(gd);
 
 		createCommentsTab(folder);
@@ -200,10 +200,10 @@ public class LanguageConfigurationInfoWidget extends Composite {
 	}
 
 	private Table createTable(final Composite parent) {
-		final Composite tableComposite = new Composite(parent, SWT.NONE);
+		final var tableComposite = new Composite(parent, SWT.NONE);
 		tableComposite.setLayoutData(new GridData(GridData.FILL_BOTH));
 		tableComposite.setLayout(new TableColumnLayout());
-		final Table table = new Table(tableComposite,
+		final var table = new Table(tableComposite,
 				SWT.BORDER | SWT.MULTI | SWT.FULL_SELECTION | SWT.H_SCROLL | SWT.V_SCROLL);
 		table.setHeaderVisible(true);
 		table.setLinesVisible(true);
@@ -211,10 +211,10 @@ public class LanguageConfigurationInfoWidget extends Composite {
 	}
 
 	private TabItem createTab(final TabFolder folder, final String title) {
-		final TabItem tab = new TabItem(folder, SWT.NONE);
+		final var tab = new TabItem(folder, SWT.NONE);
 		tab.setText(title);
 
-		final Composite parent = new Composite(folder, SWT.NONE);
+		final var parent = new Composite(folder, SWT.NONE);
 		parent.setLayout(new GridLayout());
 		parent.setLayoutData(new GridData(GridData.FILL_BOTH));
 		tab.setControl(parent);
@@ -223,10 +223,10 @@ public class LanguageConfigurationInfoWidget extends Composite {
 	}
 
 	private Text createText(final Composite parent, final String s) {
-		final Label label = new Label(parent, SWT.NONE);
+		final var label = new Label(parent, SWT.NONE);
 		label.setText(s);
 
-		final Text text = new Text(parent, SWT.BORDER);
+		final var text = new Text(parent, SWT.BORDER);
 		text.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 		text.setEditable(false);
 		return text;

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/widgets/OnEnterRuleTableWidget.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/widgets/OnEnterRuleTableWidget.java
@@ -44,29 +44,29 @@ final class OnEnterRuleTableWidget extends TableViewer {
 
 		final GC gc = new GC(table.getShell());
 		gc.setFont(JFaceResources.getDialogFont());
-		final TableColumnLayout columnLayout = new TableColumnLayout();
+		final var columnLayout = new TableColumnLayout();
 
-		final TableColumn column1 = new TableColumn(table, SWT.NONE);
+		final var column1 = new TableColumn(table, SWT.NONE);
 		column1.setText(LanguageConfigurationMessages.OnEnterRuleTableWidget_beforeText);
 		int minWidth = computeMinimumColumnWidth(gc, LanguageConfigurationMessages.OnEnterRuleTableWidget_beforeText);
 		columnLayout.setColumnData(column1, new ColumnWeightData(2, minWidth, true));
 
-		final TableColumn column2 = new TableColumn(table, SWT.NONE);
+		final var column2 = new TableColumn(table, SWT.NONE);
 		column2.setText(LanguageConfigurationMessages.OnEnterRuleTableWidget_afterText);
 		minWidth = computeMinimumColumnWidth(gc, LanguageConfigurationMessages.OnEnterRuleTableWidget_afterText);
 		columnLayout.setColumnData(column2, new ColumnWeightData(2, minWidth, true));
 
-		final TableColumn column3 = new TableColumn(table, SWT.NONE);
+		final var column3 = new TableColumn(table, SWT.NONE);
 		column3.setText(LanguageConfigurationMessages.OnEnterRuleTableWidget_indentAction);
 		minWidth = computeMinimumColumnWidth(gc, LanguageConfigurationMessages.OnEnterRuleTableWidget_indentAction);
 		columnLayout.setColumnData(column3, new ColumnWeightData(1, minWidth, true));
 
-		final TableColumn column4 = new TableColumn(table, SWT.NONE);
+		final var column4 = new TableColumn(table, SWT.NONE);
 		column4.setText(LanguageConfigurationMessages.OnEnterRuleTableWidget_appendText);
 		minWidth = computeMinimumColumnWidth(gc, LanguageConfigurationMessages.OnEnterRuleTableWidget_appendText);
 		columnLayout.setColumnData(column4, new ColumnWeightData(1, minWidth, true));
 
-		final TableColumn column5 = new TableColumn(table, SWT.NONE);
+		final var column5 = new TableColumn(table, SWT.NONE);
 		column5.setText(LanguageConfigurationMessages.OnEnterRuleTableWidget_removeText);
 		minWidth = computeMinimumColumnWidth(gc, LanguageConfigurationMessages.OnEnterRuleTableWidget_removeText);
 		columnLayout.setColumnData(column5, new ColumnWeightData(1, minWidth, true));
@@ -137,7 +137,7 @@ final class OnEnterRuleTableWidget extends TableViewer {
 			};
 		}
 	}
-	
+
 	private static <T> @NonNull T nonNull(final @Nullable T obj) {
 		if (obj != null) {
 			return obj;

--- a/org.eclipse.tm4e.languageconfiguration/src/test/java/org/eclipse/tm4e/languageconfiguration/internal/supports/OnEnterSupportTest.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/test/java/org/eclipse/tm4e/languageconfiguration/internal/supports/OnEnterSupportTest.java
@@ -28,7 +28,7 @@ public class OnEnterSupportTest {
 
 	@Test
 	public void useBrackets() {
-		final UseBracketsTest support = new UseBracketsTest();
+		final var support = new UseBracketsTest();
 
 		support.testIndentAction("a", "", IndentAction.None);
 		support.testIndentAction("", "b", IndentAction.None);
@@ -69,7 +69,7 @@ public class OnEnterSupportTest {
 
 	@Test
 	public void regExpRules() {
-		final RegExpRulesTest support = new RegExpRulesTest();
+		final var support = new RegExpRulesTest();
 
 		support.testIndentAction("\t/**", " */", IndentAction.IndentOutdent, " * ");
 		support.testIndentAction("\t/**", "", IndentAction.None, " * ");

--- a/org.eclipse.tm4e.markdown/src/main/java/org/eclipse/tm4e/markdown/TMHTMLRenderer.java
+++ b/org.eclipse.tm4e.markdown/src/main/java/org/eclipse/tm4e/markdown/TMHTMLRenderer.java
@@ -40,7 +40,7 @@ public class TMHTMLRenderer extends HTMLRenderer {
 		if (grammar == null) {
 			super.code(code, lang, escaped);
 		} else {
-			final ITokenizationSupport tokenizationSupport = new Tokenizer(grammar);
+			final var tokenizationSupport = new Tokenizer(grammar);
 			html.append("<div style=\"white-space: pre-wrap;\">");
 			tokenizeLines(code, tokenizationSupport);
 			html.append("</div>");

--- a/org.eclipse.tm4e.markdown/src/main/java/org/eclipse/tm4e/markdown/marked/BlockRules.java
+++ b/org.eclipse.tm4e.markdown/src/main/java/org/eclipse/tm4e/markdown/marked/BlockRules.java
@@ -67,22 +67,22 @@ public class BlockRules {
 	}
 
 	private static BlockRules block() {
-		final RegExp newline = new RegExp("^\\n+");
-		final RegExp code = new RegExp("^( {4}[^\\n]+\\n*)+/");
-		final RegExp fences = new RegExp("");
-		final RegExp hr = new RegExp("^( *[-*_]){3,} *(?:\\n+|$)");
-		final RegExp heading = new RegExp("^ *(#{1,6}) *([^\\n]+?) *#* *(?:\\n+|$)");
-		final RegExp nptable = new RegExp("");
-		final RegExp lheading = new RegExp("^([^\\n]+)\\n *(=|-){2,} *(?:\\n+|$)");
-		final RegExp blockquote = new RegExp("^( *>[^\\n]+(\\n(?!def)[^\\n]+)*\\n*)+");
-		final RegExp list = new RegExp("^( *)(bull) [\\s\\S]+?(?:hr|def|\\n{2,}(?! )(?!\\1bull )\\n*|\\s*$)");
-		final RegExp html = new RegExp("^ *(?:comment *(?:\\n|\\s*$)|closed *(?:\\n{2,}|\\s*$)|closing *(?:\\n{2,}|\\s*$))");
-		final RegExp def = new RegExp("^ *\\[([^\\]]+)\\]: *<?([^\\s>]+)>?(?: +[\"(]([^\\n]+)[\")])? *(?:\\n+|$)");
-		final RegExp table = RegExp.noop();
-		final RegExp paragraph = new RegExp("^((?:[^\\n]+\\n?(?!hr|heading|lheading|blockquote|tag|def))+)\\n*");
-		final RegExp text = new RegExp("^[^\\n]+");
-		final RegExp bullet = new RegExp("(?:[*+-]|\\d+\\.)");
-		final RegExp item = new RegExp("^( *)(bull) [^\\n]*(?:\\n(?!\\1bull )[^\\n]*)*");
+		final var newline = new RegExp("^\\n+");
+		final var code = new RegExp("^( {4}[^\\n]+\\n*)+/");
+		final var fences = new RegExp("");
+		final var hr = new RegExp("^( *[-*_]){3,} *(?:\\n+|$)");
+		final var heading = new RegExp("^ *(#{1,6}) *([^\\n]+?) *#* *(?:\\n+|$)");
+		final var nptable = new RegExp("");
+		final var lheading = new RegExp("^([^\\n]+)\\n *(=|-){2,} *(?:\\n+|$)");
+		final var blockquote = new RegExp("^( *>[^\\n]+(\\n(?!def)[^\\n]+)*\\n*)+");
+		final var list = new RegExp("^( *)(bull) [\\s\\S]+?(?:hr|def|\\n{2,}(?! )(?!\\1bull )\\n*|\\s*$)");
+		final var html = new RegExp("^ *(?:comment *(?:\\n|\\s*$)|closed *(?:\\n{2,}|\\s*$)|closing *(?:\\n{2,}|\\s*$))");
+		final var def = new RegExp("^ *\\[([^\\]]+)\\]: *<?([^\\s>]+)>?(?: +[\"(]([^\\n]+)[\")])? *(?:\\n+|$)");
+		final var table = RegExp.noop();
+		final var paragraph = new RegExp("^((?:[^\\n]+\\n?(?!hr|heading|lheading|blockquote|tag|def))+)\\n*");
+		final var text = new RegExp("^[^\\n]+");
+		final var bullet = new RegExp("(?:[*+-]|\\d+\\.)");
+		final var item = new RegExp("^( *)(bull) [^\\n]*(?:\\n(?!\\1bull )[^\\n]*)*");
 
 		item.replaceAll("bull", bullet);
 		list.replaceAll("bull", bullet).replace("hr", "\\n+(?=\\1?(?:[-*_] *){3,}(?:\\n+|$))").replace("def",
@@ -104,7 +104,7 @@ public class BlockRules {
 		gfm.fences.source = source;
 		// gfm.paragraph.source = "^";
 		gfm.heading.source = "^ *(#{1,6}) +([^\\n]+?) *#* *(?:\\n+|$)";
-		final String pattern = "(?!"
+		final var pattern = "(?!"
 				+ source.replaceFirst("\\\\1", "\\\\2") + "|"
 				+ source.replaceFirst("\\\\1", "\\\\3")
 				+ "|";

--- a/org.eclipse.tm4e.markdown/src/main/java/org/eclipse/tm4e/markdown/marked/InlineRules.java
+++ b/org.eclipse.tm4e.markdown/src/main/java/org/eclipse/tm4e/markdown/marked/InlineRules.java
@@ -61,19 +61,19 @@ public class InlineRules {
 	}
 
 	private static InlineRules inline() {
-		final RegExp escape = new RegExp("^\\\\([\\\\`*{}\\[\\]()#+\\-.!_>])");
-		final RegExp autolink = new RegExp("^<([^ >]+(@|:\\/)[^ >]+)>");
-		final RegExp url = RegExp.noop();
-		final RegExp tag = new RegExp("^<!--[\\s\\S]*?-->|^<\\/?\\w+(?:\"[^\"]*\"|'[^']*'|[^'\">])*?>");
-		final RegExp link = new RegExp("^!?\\[(inside)\\]\\(href\\)");
-		final RegExp reflink = new RegExp("^!?\\[(inside)\\]\\s*\\[([^\\]]*)\\]");
-		final RegExp nolink = new RegExp("^!?\\[((?:\\[[^\\]]*\\]|[^\\[\\]])*)\\]");
-		final RegExp strong = new RegExp("^__([\\s\\S]+?)__(?!_)|^\\*\\*([\\s\\S]+?)\\*\\*(?!\\*)");
-		final RegExp em = new RegExp("^\\b_((?:[^_]|__)+?)_\\b|^\\*((?:\\*\\*|[\\s\\S])+?)\\*(?!\\*)");
-		final RegExp code = new RegExp("^(`+)\\s*([\\s\\S]*?[^`])\\s*\\1(?!`)");
-		final RegExp br = new RegExp("^ {2,}\\n(?!\\s*$)");
-		final RegExp del = RegExp.noop();
-		final RegExp text = new RegExp("^[\\s\\S]+?(?=[\\\\<!\\[_*`]| {2,}\\n|$)");
+		final var escape = new RegExp("^\\\\([\\\\`*{}\\[\\]()#+\\-.!_>])");
+		final var autolink = new RegExp("^<([^ >]+(@|:\\/)[^ >]+)>");
+		final var url = RegExp.noop();
+		final var tag = new RegExp("^<!--[\\s\\S]*?-->|^<\\/?\\w+(?:\"[^\"]*\"|'[^']*'|[^'\">])*?>");
+		final var link = new RegExp("^!?\\[(inside)\\]\\(href\\)");
+		final var reflink = new RegExp("^!?\\[(inside)\\]\\s*\\[([^\\]]*)\\]");
+		final var nolink = new RegExp("^!?\\[((?:\\[[^\\]]*\\]|[^\\[\\]])*)\\]");
+		final var strong = new RegExp("^__([\\s\\S]+?)__(?!_)|^\\*\\*([\\s\\S]+?)\\*\\*(?!\\*)");
+		final var em = new RegExp("^\\b_((?:[^_]|__)+?)_\\b|^\\*((?:\\*\\*|[\\s\\S])+?)\\*(?!\\*)");
+		final var code = new RegExp("^(`+)\\s*([\\s\\S]*?[^`])\\s*\\1(?!`)");
+		final var br = new RegExp("^ {2,}\\n(?!\\s*$)");
+		final var del = RegExp.noop();
+		final var text = new RegExp("^[\\s\\S]+?(?=[\\\\<!\\[_*`]| {2,}\\n|$)");
 		// Replacement
 		link.replace("inside", INLINE_INSIDE).replace("href", INLINE_HREF);
 		reflink.replace("inside", INLINE_INSIDE);

--- a/org.eclipse.tm4e.markdown/src/main/java/org/eclipse/tm4e/markdown/marked/Lexer.java
+++ b/org.eclipse.tm4e.markdown/src/main/java/org/eclipse/tm4e/markdown/marked/Lexer.java
@@ -43,7 +43,7 @@ public class Lexer {
 	}
 
 	public static Tokens lex(final String src, @Nullable final Options options) {
-		final Lexer lexer = new Lexer(options);
+		final var lexer = new Lexer(options);
 		return lexer.lex(src);
 	}
 

--- a/org.eclipse.tm4e.markdown/src/main/java/org/eclipse/tm4e/markdown/marked/Parser.java
+++ b/org.eclipse.tm4e.markdown/src/main/java/org/eclipse/tm4e/markdown/marked/Parser.java
@@ -35,7 +35,7 @@ public class Parser {
 
 	public static IRenderer parse(final Tokens src, @Nullable final Options options,
 			@Nullable final IRenderer renderer) {
-		final Parser parser = new Parser(options, renderer);
+		final var parser = new Parser(options, renderer);
 		return parser.parse(src);
 	}
 

--- a/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/TMResource.java
+++ b/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/TMResource.java
@@ -99,7 +99,7 @@ public class TMResource implements ITMResource {
 	}
 
 	private static String convertStreamToString(final InputStream is) {
-		try (Scanner s = new Scanner(is)) {
+		try (var s = new Scanner(is)) {
 			s.useDelimiter("\\A");
 			return s.hasNext() ? s.next() : "";
 		}

--- a/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/internal/AbstractGrammarRegistryManager.java
+++ b/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/internal/AbstractGrammarRegistryManager.java
@@ -148,7 +148,7 @@ public abstract class AbstractGrammarRegistryManager extends Registry implements
 	public IGrammarDefinition[] getDefinitions() {
 		final Collection<IGrammarDefinition> pluginDefinitions = pluginCache.getDefinitions();
 		final Collection<IGrammarDefinition> userDefinitions = userCache.getDefinitions();
-		final Collection<IGrammarDefinition> definitions = new ArrayList<>(pluginDefinitions);
+		final var definitions = new ArrayList<>(pluginDefinitions);
 		definitions.addAll(userDefinitions);
 		return definitions.toArray(IGrammarDefinition[]::new);
 	}

--- a/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/internal/GrammarRegistryManager.java
+++ b/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/internal/GrammarRegistryManager.java
@@ -46,7 +46,7 @@ public final class GrammarRegistryManager extends AbstractGrammarRegistryManager
 		if (INSTANCE != null) {
 			return INSTANCE;
 		}
-		final GrammarRegistryManager manager = new GrammarRegistryManager();
+		final var manager = new GrammarRegistryManager();
 		manager.load();
 		return manager;
 	}

--- a/org.eclipse.tm4e.ui.tests/src/main/java/org/eclipse/tm4e/ui/TMinGenericEditorTest.java
+++ b/org.eclipse.tm4e.ui.tests/src/main/java/org/eclipse/tm4e/ui/TMinGenericEditorTest.java
@@ -89,7 +89,7 @@ class TMinGenericEditorTest {
 	@Test
 	void testTMHighlightInGenericEditor() throws IOException, PartInitException {
 		f = File.createTempFile("test" + System.currentTimeMillis(), ".ts");
-		try (FileOutputStream fileOutputStream = new FileOutputStream(f)) {
+		try (var fileOutputStream = new FileOutputStream(f)) {
 			fileOutputStream.write("let a = '';\nlet b = 10;\nlet c = true;".getBytes());
 		}
 		f.deleteOnExit();
@@ -107,7 +107,7 @@ class TMinGenericEditorTest {
 	@Test
 	void testTMHighlightInGenericEditorEdit() throws IOException, PartInitException {
 		f = File.createTempFile("test" + System.currentTimeMillis(), ".ts");
-		try (FileOutputStream fileOutputStream = new FileOutputStream(f)) {
+		try (var fileOutputStream = new FileOutputStream(f)) {
 			fileOutputStream.write("let a = '';".getBytes());
 		}
 		f.deleteOnExit();

--- a/org.eclipse.tm4e.ui.tests/src/main/java/org/eclipse/tm4e/ui/internal/model/DocumentTMModelTest.java
+++ b/org.eclipse.tm4e.ui.tests/src/main/java/org/eclipse/tm4e/ui/internal/model/DocumentTMModelTest.java
@@ -19,8 +19,8 @@ class DocumentTMModelTest {
 
 	@Test
 	void testMultiLineChange() throws Exception {
-		final Document document = new Document();
-		final TMDocumentModel model = new TMDocumentModel(document);
+		final var document = new Document();
+		final var model = new TMDocumentModel(document);
 		try {
 			model.setGrammar(new Registry().loadGrammarFromPathSync("TypeScript.tmLanguage.json", getClass().getClassLoader().getResourceAsStream("/grammars/TypeScript.tmLanguage.json")));
 			document.set("a\nb\nc\nd");

--- a/org.eclipse.tm4e.ui.tests/src/main/java/org/eclipse/tm4e/ui/internal/text/Command.java
+++ b/org.eclipse.tm4e.ui.tests/src/main/java/org/eclipse/tm4e/ui/internal/text/Command.java
@@ -50,7 +50,7 @@ public abstract class Command implements ICommand {
 	protected abstract Integer getLineTo();
 
 	public static String toText(final String text) {
-		final StringBuilder newText = new StringBuilder();
+		final var newText = new StringBuilder();
 		for (int i = 0; i < text.length(); i++) {
 			final char c = text.charAt(i);
 			switch (c) {

--- a/org.eclipse.tm4e.ui.tests/src/main/java/org/eclipse/tm4e/ui/text/TMEditor.java
+++ b/org.eclipse.tm4e.ui.tests/src/main/java/org/eclipse/tm4e/ui/text/TMEditor.java
@@ -60,7 +60,7 @@ public class TMEditor {
 	}
 
 	private void setAndExecute(final String text) {
-		final Command command = new DocumentSetCommand(text, document);
+		final var command = new DocumentSetCommand(text, document);
 		commands.add(command);
 		collector.setCommand(command);
 	}

--- a/org.eclipse.tm4e.ui.tests/src/main/java/org/eclipse/tm4e/ui/text/typescript/TMPresentationReconcilerTypeScriptTest.java
+++ b/org.eclipse.tm4e.ui.tests/src/main/java/org/eclipse/tm4e/ui/text/typescript/TMPresentationReconcilerTypeScriptTest.java
@@ -30,7 +30,7 @@ public class TMPresentationReconcilerTypeScriptTest {
 	@Test
 	void colorizeTypescript() throws Exception {
 
-		final TMEditor editor = new TMEditor(getGrammar(), getTokenProvider(), "let a = '';\nlet b = 10;\nlet c = true;");
+		final var editor = new TMEditor(getGrammar(), getTokenProvider(), "let a = '';\nlet b = 10;\nlet c = true;");
 		final List<ICommand> commands = editor.execute();
 
 		assertEquals(1, commands.size());
@@ -70,7 +70,7 @@ public class TMPresentationReconcilerTypeScriptTest {
 	@Test
 	void colorizeTypescriptWithInvalidate1() throws Exception {
 
-		final TMEditor editor = new TMEditor(getGrammar(), getTokenProvider(), "let a = '';\nlet b = 10;\nlet c = true;");
+		final var editor = new TMEditor(getGrammar(), getTokenProvider(), "let a = '';\nlet b = 10;\nlet c = true;");
 		editor.invalidateTextPresentation(0, 3);
 		final List<ICommand> commands = editor.execute();
 
@@ -119,7 +119,7 @@ public class TMPresentationReconcilerTypeScriptTest {
 	@Test
 	void colorizeTypescriptWithInvalidate2() throws Exception {
 
-		final TMEditor editor = new TMEditor(getGrammar(), getTokenProvider(), "let a = '';\nlet b = 10;\nlet c = true;");
+		final var editor = new TMEditor(getGrammar(), getTokenProvider(), "let a = '';\nlet b = 10;\nlet c = true;");
 		editor.invalidateTextPresentation(0, 2);
 		final List<ICommand> commands = editor.execute();
 
@@ -168,7 +168,7 @@ public class TMPresentationReconcilerTypeScriptTest {
 	@Test
 	void colorizeTypescriptWithInvalidate3() throws Exception {
 
-		final TMEditor editor = new TMEditor(getGrammar(), getTokenProvider(), "let a = '';\nlet b = 10;\nlet c = true;");
+		final var editor = new TMEditor(getGrammar(), getTokenProvider(), "let a = '';\nlet b = 10;\nlet c = true;");
 		editor.invalidateTextPresentation(1, 2);
 		final List<ICommand> commands = editor.execute();
 
@@ -217,7 +217,7 @@ public class TMPresentationReconcilerTypeScriptTest {
 	@Test
 	void colorizeTypescriptWithInvalidate4() throws Exception {
 
-		final TMEditor editor = new TMEditor(getGrammar(), getTokenProvider(), "let a = '';\nlet b = 10;\nlet c = true;");
+		final var editor = new TMEditor(getGrammar(), getTokenProvider(), "let a = '';\nlet b = 10;\nlet c = true;");
 		editor.invalidateTextPresentation(1, 1);
 		final List<ICommand> commands = editor.execute();
 
@@ -266,7 +266,7 @@ public class TMPresentationReconcilerTypeScriptTest {
 	@Test
 	void colorizeTypescriptWithInvalidate8() throws Exception {
 
-		final TMEditor editor = new TMEditor(getGrammar(), getTokenProvider(), "let a = '';\nlet b = 10;\nlet c = true;");
+		final var editor = new TMEditor(getGrammar(), getTokenProvider(), "let a = '';\nlet b = 10;\nlet c = true;");
 		editor.invalidateTextPresentation(1, 8);
 		final List<ICommand> commands = editor.execute();
 
@@ -315,7 +315,7 @@ public class TMPresentationReconcilerTypeScriptTest {
 	@Test
 	void colorizeTypescriptWithInvalidateAndSeveralLines() throws Exception {
 
-		final TMEditor editor = new TMEditor(getGrammar(), getTokenProvider(), "a\r\n\r\nb");
+		final var editor = new TMEditor(getGrammar(), getTokenProvider(), "a\r\n\r\nb");
 		editor.invalidateTextPresentation(0, 6);
 
 		final List<ICommand> commands = editor.execute();
@@ -338,7 +338,7 @@ public class TMPresentationReconcilerTypeScriptTest {
 	}
 
 	public static IGrammar getGrammar() {
-		final Registry registry = new Registry();
+		final var registry = new Registry();
 		try {
 			return registry.loadGrammarFromPathSync("TypeScript.tmLanguage.json",
 					TMPresentationReconcilerTypeScriptTest.class.getClassLoader().getResourceAsStream("/grammars/TypeScript.tmLanguage.json"));

--- a/org.eclipse.tm4e.ui.tests/src/main/java/org/eclipse/tm4e/ui/themes/TMEditorColorTest.java
+++ b/org.eclipse.tm4e.ui.tests/src/main/java/org/eclipse/tm4e/ui/themes/TMEditorColorTest.java
@@ -90,9 +90,9 @@ class TMEditorColorTest implements ThemeIdConstants {
 
 	@Test
 	void userDefinedEditorColorTest() throws Exception {
-		final String testColorVal = "255,128,0";
-		final Color testColor = new Color(Display.getCurrent(), 255, 128, 0);
-		final IPreferenceStore prefs = new ScopedPreferenceStore(InstanceScope.INSTANCE, "org.eclipse.ui.editors");
+		final var testColorVal = "255,128,0";
+		final var testColor = new Color(Display.getCurrent(), 255, 128, 0);
+		final var prefs = new ScopedPreferenceStore(InstanceScope.INSTANCE, "org.eclipse.ui.editors");
 		prefs.setValue(AbstractTextEditor.PREFERENCE_COLOR_BACKGROUND, testColorVal);
 		prefs.setValue(AbstractTextEditor.PREFERENCE_COLOR_BACKGROUND_SYSTEM_DEFAULT, false);
 

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/menus/ThemeContribution.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/menus/ThemeContribution.java
@@ -51,7 +51,7 @@ public final class ThemeContribution extends CompoundContributionItem implements
 
 	@Override
 	protected IContributionItem[] getContributionItems() {
-		final List<IContributionItem> items = new ArrayList<>();
+		final var items = new ArrayList<IContributionItem>();
 		if (handlerService != null) {
 			final IEditorPart editorPart = getActivePart(handlerService.getCurrentState());
 			if (editorPart != null) {
@@ -70,7 +70,7 @@ public final class ThemeContribution extends CompoundContributionItem implements
 							if (theme.equals(selectedTheme)) {
 								action.setChecked(true);
 							}
-							final IContributionItem item = new ActionContributionItem(action);
+							final var item = new ActionContributionItem(action);
 							items.add(item);
 						}
 					}
@@ -86,7 +86,7 @@ public final class ThemeContribution extends CompoundContributionItem implements
 			@Override
 			public void run() {
 				final IThemeManager manager = TMUIPlugin.getThemeManager();
-				final IThemeAssociation association = new ThemeAssociation(theme.getId(), scopeName, whenDark);
+				final var association = new ThemeAssociation(theme.getId(), scopeName, whenDark);
 				manager.registerThemeAssociation(association);
 				try {
 					manager.save();

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/preferences/TextMatePreferencePage.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/preferences/TextMatePreferencePage.java
@@ -32,8 +32,8 @@ public final class TextMatePreferencePage extends PreferencePage implements IWor
 
 	@Override
 	protected Control createContents(@Nullable final Composite parent) {
-		final Composite composite = new Composite(parent, SWT.NONE);
-		final GridLayout layout = new GridLayout(1, false);
+		final var composite = new Composite(parent, SWT.NONE);
+		final var layout = new GridLayout(1, false);
 		layout.marginHeight = layout.marginWidth = 0;
 		composite.setLayout(layout);
 
@@ -55,10 +55,10 @@ public final class TextMatePreferencePage extends PreferencePage implements IWor
 	}
 
 	private void addRelatedLink(final Composite parent, final String pageId, final String message) {
-		final PreferenceLinkArea contentTypeArea = new PreferenceLinkArea(parent, SWT.NONE, pageId, message,
+		final var contentTypeArea = new PreferenceLinkArea(parent, SWT.NONE, pageId, message,
 				(IWorkbenchPreferenceContainer) getContainer(), null);
 
-		final GridData data = new GridData(GridData.FILL_HORIZONTAL | GridData.GRAB_HORIZONTAL);
+		final var data = new GridData(GridData.FILL_HORIZONTAL | GridData.GRAB_HORIZONTAL);
 		contentTypeArea.getControl().setLayoutData(data);
 	}
 

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/preferences/ThemePreferencePage.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/preferences/ThemePreferencePage.java
@@ -101,20 +101,20 @@ public final class ThemePreferencePage extends PreferencePage implements IWorkbe
 
 	@Override
 	protected Control createContents(@Nullable final Composite ancestor) {
-		final Composite parent = new Composite(ancestor, SWT.NONE);
-		final GridLayout layout = new GridLayout();
+		final var parent = new Composite(ancestor, SWT.NONE);
+		final var layout = new GridLayout();
 		layout.numColumns = 2;
 		layout.marginHeight = 0;
 		layout.marginWidth = 0;
 		parent.setLayout(layout);
 
-		final Composite innerParent = new Composite(parent, SWT.NONE);
-		final GridLayout innerLayout = new GridLayout();
+		final var innerParent = new Composite(parent, SWT.NONE);
+		final var innerLayout = new GridLayout();
 		innerLayout.numColumns = 2;
 		innerLayout.marginHeight = 0;
 		innerLayout.marginWidth = 0;
 		innerParent.setLayout(innerLayout);
-		final GridData gd = new GridData(GridData.FILL_BOTH);
+		final var gd = new GridData(GridData.FILL_BOTH);
 		gd.horizontalSpan = 2;
 		innerParent.setLayoutData(gd);
 
@@ -143,15 +143,15 @@ public final class ThemePreferencePage extends PreferencePage implements IWorkbe
 	 */
 	private void createThemesContent(final Composite parent) {
 		GridLayout layout;
-		final Composite tableComposite = new Composite(parent, SWT.NONE);
-		final GridData data = new GridData(GridData.FILL_BOTH);
+		final var tableComposite = new Composite(parent, SWT.NONE);
+		final var data = new GridData(GridData.FILL_BOTH);
 		data.widthHint = 360;
 		data.heightHint = convertHeightInCharsToPixels(10);
 		tableComposite.setLayoutData(data);
 
-		final TableColumnLayout columnLayout = new TableColumnLayout();
+		final var columnLayout = new TableColumnLayout();
 		tableComposite.setLayout(columnLayout);
-		final Table table = new Table(tableComposite,
+		final var table = new Table(tableComposite,
 				SWT.BORDER | SWT.MULTI | SWT.FULL_SELECTION | SWT.H_SCROLL | SWT.V_SCROLL);
 
 		table.setHeaderVisible(true);
@@ -160,23 +160,23 @@ public final class ThemePreferencePage extends PreferencePage implements IWorkbe
 		final GC gc = new GC(getShell());
 		gc.setFont(JFaceResources.getDialogFont());
 
-		final ColumnViewerComparator viewerComparator = new ColumnViewerComparator();
+		final var viewerComparator = new ColumnViewerComparator();
 
 		final var themeViewer = this.themeViewer = new TableViewer(table);
 
-		final TableColumn column1 = new TableColumn(table, SWT.NONE);
+		final var column1 = new TableColumn(table, SWT.NONE);
 		column1.setText(TMUIMessages.ThemePreferencePage_column_name);
 		int minWidth = computeMinimumColumnWidth(gc, TMUIMessages.ThemePreferencePage_column_name);
 		columnLayout.setColumnData(column1, new ColumnWeightData(2, minWidth, true));
 		column1.addSelectionListener(new ColumnSelectionAdapter(column1, themeViewer, 0, viewerComparator));
 
-		final TableColumn column2 = new TableColumn(table, SWT.NONE);
+		final var column2 = new TableColumn(table, SWT.NONE);
 		column2.setText(TMUIMessages.ThemePreferencePage_column_path);
 		minWidth = computeMinimumColumnWidth(gc, TMUIMessages.ThemePreferencePage_column_path);
 		columnLayout.setColumnData(column2, new ColumnWeightData(2, minWidth, true));
 		column2.addSelectionListener(new ColumnSelectionAdapter(column2, themeViewer, 1, viewerComparator));
 
-		final TableColumn column3 = new TableColumn(table, SWT.NONE);
+		final var column3 = new TableColumn(table, SWT.NONE);
 		column3.setText(TMUIMessages.ThemePreferencePage_column_pluginId);
 		minWidth = computeMinimumColumnWidth(gc, TMUIMessages.ThemePreferencePage_column_pluginId);
 		columnLayout.setColumnData(column3, new ColumnWeightData(2, minWidth, true));
@@ -205,14 +205,14 @@ public final class ThemePreferencePage extends PreferencePage implements IWorkbe
 
 		BidiUtils.applyTextDirection(themeViewer.getControl(), BidiUtils.BTD_DEFAULT);
 
-		final Composite buttons = new Composite(parent, SWT.NONE);
+		final var buttons = new Composite(parent, SWT.NONE);
 		buttons.setLayoutData(new GridData(GridData.VERTICAL_ALIGN_BEGINNING));
 		layout = new GridLayout();
 		layout.marginHeight = 0;
 		layout.marginWidth = 0;
 		buttons.setLayout(layout);
 
-		final Button themeNewButton = new Button(buttons, SWT.PUSH);
+		final var themeNewButton = new Button(buttons, SWT.PUSH);
 		themeNewButton.setText(TMUIMessages.Button_new);
 		themeNewButton.setLayoutData(getButtonGridData(themeNewButton));
 		themeNewButton.addListener(SWT.Selection, new Listener() {
@@ -229,14 +229,14 @@ public final class ThemePreferencePage extends PreferencePage implements IWorkbe
 
 			@Nullable
 			private ITheme addTheme() {
-				final FileDialog dialog = new FileDialog(getShell());
+				final var dialog = new FileDialog(getShell());
 				dialog.setText("Select textmate theme file");
 				dialog.setFilterExtensions(new String[] { "*.css" });
 				final String res = dialog.open();
 				if (res == null) {
 					return null;
 				}
-				final File file = new File(res);
+				final var file = new File(res);
 				final String name = file.getName().substring(0, file.getName().length() - ".css".length());
 				return new Theme(name, file.getAbsolutePath(), name, false, false);
 			}
@@ -259,8 +259,8 @@ public final class ThemePreferencePage extends PreferencePage implements IWorkbe
 	 * @param parent
 	 */
 	private void createThemeDetailContent(final Composite ancestor) {
-		final Composite parent = new Composite(ancestor, SWT.NONE);
-		final GridData data = new GridData(GridData.FILL_HORIZONTAL);
+		final var parent = new Composite(ancestor, SWT.NONE);
+		final var data = new GridData(GridData.FILL_HORIZONTAL);
 		data.horizontalSpan = 2;
 		parent.setLayoutData(data);
 
@@ -286,12 +286,12 @@ public final class ThemePreferencePage extends PreferencePage implements IWorkbe
 	 * @param parent
 	 */
 	private void createPreviewContent(final Composite ancestor) {
-		final Composite parent = new Composite(ancestor, SWT.NONE);
-		final GridData data = new GridData(GridData.FILL_HORIZONTAL);
+		final var parent = new Composite(ancestor, SWT.NONE);
+		final var data = new GridData(GridData.FILL_HORIZONTAL);
 		data.horizontalSpan = 2;
 		parent.setLayoutData(data);
 
-		final GridLayout layout = new GridLayout(2, false);
+		final var layout = new GridLayout(2, false);
 		layout.marginHeight = 0;
 		layout.marginWidth = 0;
 		parent.setLayout(layout);
@@ -308,7 +308,7 @@ public final class ThemePreferencePage extends PreferencePage implements IWorkbe
 	 * @returns the grid data for the button.
 	 */
 	private static GridData getButtonGridData(final Button button) {
-		final GridData data = new GridData(GridData.FILL_HORIZONTAL);
+		final var data = new GridData(GridData.FILL_HORIZONTAL);
 		// TODO replace SWTUtil
 		// data.widthHint= SWTUtil.getButtonWidthHint(button);
 		// data.heightHint= SWTUtil.getButtonHeightHint(button);
@@ -349,9 +349,9 @@ public final class ThemePreferencePage extends PreferencePage implements IWorkbe
 	}
 
 	private TMViewer doCreateViewer(final Composite parent) {
-		final Label label = new Label(parent, SWT.NONE);
+		final var label = new Label(parent, SWT.NONE);
 		label.setText(TMUIMessages.ThemePreferencePage_preview);
-		GridData data = new GridData();
+		var data = new GridData();
 		label.setLayoutData(data);
 
 		final var grammarViewer = this.grammarViewer = new ComboViewer(parent);
@@ -366,7 +366,7 @@ public final class ThemePreferencePage extends PreferencePage implements IWorkbe
 		// https://bugs.eclipse.org/293263
 		// viewer.getTextWidget().setCaret(null);
 
-		final Control control = viewer.getControl();
+		final var control = viewer.getControl();
 		data = new GridData(GridData.FILL_BOTH);
 		data.horizontalSpan = 2;
 		data.heightHint = convertHeightInCharsToPixels(5);

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/text/TMPresentationReconcilerTestGenerator.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/text/TMPresentationReconcilerTestGenerator.java
@@ -96,7 +96,7 @@ public final class TMPresentationReconcilerTestGenerator
 	}
 
 	private String toText(final String text) {
-		final StringBuilder newText = new StringBuilder();
+		final var newText = new StringBuilder();
 		for (int i = 0; i < text.length(); i++) {
 			final char c = text.charAt(i);
 			switch (c) {

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/themes/AbstractThemeManager.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/themes/AbstractThemeManager.java
@@ -109,7 +109,7 @@ public abstract class AbstractThemeManager implements IThemeManager {
 
 	@Override
 	public IThemeAssociation[] getThemeAssociationsForScope(final String scopeName) {
-		final List<IThemeAssociation> associations = new ArrayList<>();
+		final var associations = new ArrayList<IThemeAssociation>();
 		IThemeAssociation light = themeAssociationRegistry.getThemeAssociationFor(scopeName, false);
 		if (light == null) {
 			light = new ThemeAssociation(getDefaultTheme(false).getId(), scopeName, false);

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/themes/ThemeManager.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/themes/ThemeManager.java
@@ -60,7 +60,7 @@ public final class ThemeManager extends AbstractThemeManager {
 		if (INSTANCE != null) {
 			return INSTANCE;
 		}
-		final ThemeManager manager = new ThemeManager();
+		final var manager = new ThemeManager();
 		manager.load();
 		return manager;
 	}
@@ -124,7 +124,7 @@ public final class ThemeManager extends AbstractThemeManager {
 		prefs.put(PreferenceConstants.THEMES, Arrays.stream(getThemes()) //
 				.filter(t -> t.getPluginId() == null) //
 				.map(theme -> {
-					final JsonObject json = new JsonObject();
+					final var json = new JsonObject();
 					json.addProperty("id", theme.getId());
 					json.addProperty("path", theme.getPath());
 					json.addProperty("dark", theme.isDark());

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/utils/ContentTypeHelper.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/utils/ContentTypeHelper.java
@@ -105,7 +105,7 @@ public final class ContentTypeHelper {
 	private static ContentTypeInfo getContentTypes(final ITextFileBuffer buffer) throws CoreException {
 		try {
 			final String fileName = buffer.getFileStore().getName();
-			final Collection<IContentType> contentTypes = new LinkedHashSet<>();
+			final var contentTypes = new LinkedHashSet<IContentType>();
 			final IContentType bufferContentType = buffer.getContentType();
 			if (bufferContentType != null) {
 				contentTypes.add(bufferContentType);
@@ -113,7 +113,7 @@ public final class ContentTypeHelper {
 			if (buffer.isDirty()) {
 				// Buffer is dirty (content of the filesystem is not synch with
 				// the editor content), use IDocument content.
-				try (InputStream input = new DocumentInputStream(buffer.getDocument())) {
+				try (var input = new DocumentInputStream(buffer.getDocument())) {
 					final IContentType[] contentTypesForInput = Platform.getContentTypeManager().findContentTypesFor(input, fileName);
 					if (contentTypesForInput != null) {
 						contentTypes.addAll(Arrays.asList(contentTypesForInput));

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/widgets/GrammarInfoWidget.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/widgets/GrammarInfoWidget.java
@@ -36,7 +36,7 @@ public final class GrammarInfoWidget extends Composite {
 
 	public GrammarInfoWidget(final Composite parent, final int style) {
 		super(parent, style);
-		final GridLayout layout = new GridLayout();
+		final var layout = new GridLayout();
 		layout.marginHeight = 0;
 		layout.marginWidth = 0;
 		layout.marginLeft = 0;
@@ -44,8 +44,8 @@ public final class GrammarInfoWidget extends Composite {
 		super.setLayout(layout);
 		super.setLayoutData(new GridData(GridData.FILL_BOTH));
 
-		final Composite container = new Composite(this, SWT.NONE);
-		final GridLayout containerLayout = new GridLayout(2, false);
+		final var container = new Composite(this, SWT.NONE);
+		final var containerLayout = new GridLayout(2, false);
 		containerLayout.marginHeight = 0;
 		containerLayout.marginWidth = 0;
 		containerLayout.marginLeft = 0;
@@ -53,17 +53,17 @@ public final class GrammarInfoWidget extends Composite {
 		container.setLayout(containerLayout);
 		container.setLayoutData(new GridData(GridData.FILL_BOTH));
 
-		final Label grammarNameLabel = new Label(container, SWT.NONE);
+		final var grammarNameLabel = new Label(container, SWT.NONE);
 		grammarNameLabel.setText(TMUIMessages.GrammarInfoWidget_name_text);
 		nameText = new Text(container, SWT.BORDER | SWT.READ_ONLY);
 		nameText.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 
-		final Label grammarScopeNameLabel = new Label(container, SWT.NONE);
+		final var grammarScopeNameLabel = new Label(container, SWT.NONE);
 		grammarScopeNameLabel.setText(TMUIMessages.GrammarInfoWidget_scopeName_text);
 		scopeNameText = new Text(container, SWT.BORDER | SWT.READ_ONLY);
 		scopeNameText.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 
-		final Label grammarFileTypesLabel = new Label(container, SWT.NONE);
+		final var grammarFileTypesLabel = new Label(container, SWT.NONE);
 		grammarFileTypesLabel.setText(TMUIMessages.GrammarInfoWidget_fileTypes_text);
 		fileTypesText = new Text(container, SWT.BORDER | SWT.READ_ONLY);
 		fileTypesText.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/widgets/TableAndButtonsWidget.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/widgets/TableAndButtonsWidget.java
@@ -37,7 +37,7 @@ public abstract class TableAndButtonsWidget extends Composite {
 
 	protected TableAndButtonsWidget(final Composite parent, final int style, final String title) {
 		super(parent, style);
-		final GridLayout layout = new GridLayout();
+		final var layout = new GridLayout();
 		layout.marginHeight = 0;
 		layout.marginWidth = 0;
 		layout.marginLeft = 0;
@@ -47,8 +47,8 @@ public abstract class TableAndButtonsWidget extends Composite {
 	}
 
 	private void createUI(final String title, final Composite ancestor) {
-		final Composite parent = new Composite(ancestor, SWT.NONE);
-		GridLayout layout = new GridLayout(2, false);
+		final var parent = new Composite(ancestor, SWT.NONE);
+		var layout = new GridLayout(2, false);
 		layout.marginHeight = 0;
 		layout.marginWidth = 0;
 		layout.marginLeft = 0;
@@ -63,7 +63,7 @@ public abstract class TableAndButtonsWidget extends Composite {
 		createTable(parent);
 
 		// Buttons
-		final Composite buttonsComposite = new Composite(parent, SWT.NONE);
+		final var buttonsComposite = new Composite(parent, SWT.NONE);
 		layout = new GridLayout();
 		layout.marginHeight = 0;
 		layout.marginWidth = 0;
@@ -77,15 +77,15 @@ public abstract class TableAndButtonsWidget extends Composite {
 	protected abstract void createButtons(Composite parent);
 
 	private void createTitle(final String title, final Composite ancestor) {
-		final Label label = new Label(ancestor, SWT.NONE);
+		final var label = new Label(ancestor, SWT.NONE);
 		label.setText(title);
-		final GridData data = new GridData(GridData.FILL_HORIZONTAL);
+		final var data = new GridData(GridData.FILL_HORIZONTAL);
 		data.horizontalSpan = 2;
 		label.setLayoutData(data);
 	}
 
 	private void createTable(final Composite parent) {
-		final Table table = new Table(parent,
+		final var table = new Table(parent,
 				SWT.BORDER | SWT.MULTI | SWT.FULL_SELECTION | SWT.H_SCROLL | SWT.V_SCROLL);
 		table.setHeaderVisible(false);
 		table.setLinesVisible(false);

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/widgets/ThemeAssociationsWidget.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/widgets/ThemeAssociationsWidget.java
@@ -62,12 +62,12 @@ public final class ThemeAssociationsWidget extends TableAndButtonsWidget {
 		editButton.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 		editButton.addListener(SWT.Selection, e -> {
 			// Open the wizard to create association between theme and grammar.
-			final CreateThemeAssociationWizard wizard = new CreateThemeAssociationWizard(false);
+			final var wizard = new CreateThemeAssociationWizard(false);
 			wizard.setInitialDefinition(definition);
 			final IStructuredSelection selection = super.getSelection();
 			wizard.setInitialAssociation(selection.isEmpty() ? null : (IThemeAssociation) selection.getFirstElement());
 			wizard.setThemeManager(themeManager);
-			final WizardDialog dialog = new WizardDialog(getShell(), wizard);
+			final var dialog = new WizardDialog(getShell(), wizard);
 			if (dialog.open() == Window.OK) {
 				final IThemeAssociation association = wizard.getCreatedThemeAssociation();
 				refresh(association);

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/wizards/AbstractWizardPage.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/wizards/AbstractWizardPage.java
@@ -46,7 +46,7 @@ abstract class AbstractWizardPage extends WizardPage implements Listener {
 
 		initializeDialogUnits(parent);
 		// top level group
-		final Composite topLevel = new Composite(parent, SWT.NONE);
+		final var topLevel = new Composite(parent, SWT.NONE);
 		topLevel.setLayout(new GridLayout());
 		topLevel.setLayoutData(new GridData(GridData.VERTICAL_ALIGN_FILL | GridData.HORIZONTAL_ALIGN_FILL));
 		topLevel.setFont(parent.getFont());

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/wizards/CreateThemeAssociationWizardPage.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/wizards/CreateThemeAssociationWizardPage.java
@@ -70,13 +70,13 @@ final class CreateThemeAssociationWizardPage extends AbstractWizardPage {
 
 	@Override
 	protected void createBody(final Composite ancestor) {
-		final Composite parent = new Composite(ancestor, SWT.NONE);
+		final var parent = new Composite(ancestor, SWT.NONE);
 		parent.setFont(parent.getFont());
 		parent.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 		parent.setLayout(new GridLayout(4, false));
 
 		// TextMate theme
-		Label label = new Label(parent, SWT.NONE);
+		var label = new Label(parent, SWT.NONE);
 		label.setText(TMUIMessages.CreateThemeAssociationWizardPage_theme_text);
 		final var themeViewer = this.themeViewer = new ComboViewer(parent);
 		themeViewer.setLabelProvider(new ThemeLabelProvider());
@@ -100,7 +100,7 @@ final class CreateThemeAssociationWizardPage extends AbstractWizardPage {
 
 		final var whenDarkButton = this.whenDarkButton = new Button(parent, SWT.CHECK);
 		whenDarkButton.setText(TMUIMessages.CreateThemeAssociationWizardPage_whenDark_text);
-		final GridData data = new GridData();
+		final var data = new GridData();
 		data.horizontalSpan = 4;
 		whenDarkButton.setLayoutData(data);
 

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/wizards/SelectGrammarWizardPage.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/wizards/SelectGrammarWizardPage.java
@@ -70,7 +70,7 @@ final class SelectGrammarWizardPage extends AbstractWizardPage {
 
 	@Override
 	protected void createBody(final Composite ancestor) {
-		final Composite parent = new Composite(ancestor, SWT.NONE);
+		final var parent = new Composite(ancestor, SWT.NONE);
 		parent.setFont(parent.getFont());
 		parent.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 		parent.setLayout(new GridLayout(2, false));
@@ -81,9 +81,9 @@ final class SelectGrammarWizardPage extends AbstractWizardPage {
 		grammarFileText.addListener(SWT.Modify, this);
 
 		// Buttons
-		final Composite buttons = new Composite(parent, SWT.NONE);
+		final var buttons = new Composite(parent, SWT.NONE);
 		buttons.setLayout(new GridLayout(2, false));
-		final GridData gd = new GridData(GridData.FILL_HORIZONTAL);
+		final var gd = new GridData(GridData.FILL_HORIZONTAL);
 		gd.horizontalSpan = 2;
 		gd.horizontalAlignment = SWT.RIGHT;
 		buttons.setLayoutData(gd);
@@ -112,7 +112,7 @@ final class SelectGrammarWizardPage extends AbstractWizardPage {
 			}
 		});
 
-		final GridData data = new GridData(GridData.FILL_HORIZONTAL);
+		final var data = new GridData(GridData.FILL_HORIZONTAL);
 		data.horizontalSpan = 2;
 		grammarInfoWidget = new GrammarInfoWidget(parent, SWT.NONE);
 		grammarInfoWidget.setLayoutData(data);

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/text/TMPresentationReconciler.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/text/TMPresentationReconciler.java
@@ -206,7 +206,7 @@ public class TMPresentationReconciler implements IPresentationReconciler {
 		@Override
 		public void inputDocumentAboutToBeChanged(@Nullable final IDocument oldDocument,
 				@Nullable final IDocument newDocument) {
-			if (oldDocument == null) 
+			if (oldDocument == null)
 			   return;
 
 			final var viewer = TMPresentationReconciler.this.viewer;
@@ -417,7 +417,7 @@ public class TMPresentationReconciler implements IPresentationReconciler {
 						final int length = document.getLineOffset(range.toLineNumber - 1)
 								+ document.getLineLength(range.toLineNumber - 1)
 								- document.getLineOffset(range.fromLineNumber - 1);
-						final IRegion region = new Region(document.getLineOffset(range.fromLineNumber - 1), length);
+						final var region = new Region(document.getLineOffset(range.fromLineNumber - 1), length);
 						TMPresentationReconciler.this.colorize(region, docModel);
 					} catch (final BadLocationException ex) {
 						TMUIPlugin.log(new Status(IStatus.ERROR, TMUIPlugin.PLUGIN_ID, ex.getMessage(), ex));
@@ -702,7 +702,7 @@ public class TMPresentationReconciler implements IPresentationReconciler {
 		if (attr != null) {
 			final int style = attr.getStyle();
 			final int fontStyle = style & (SWT.ITALIC | SWT.BOLD | SWT.NORMAL);
-			final StyleRange styleRange = new StyleRange(offset, length, attr.getForeground(), attr.getBackground(),
+			final var styleRange = new StyleRange(offset, length, attr.getForeground(), attr.getBackground(),
 					fontStyle);
 			styleRange.strikeout = (style & TextAttribute.STRIKETHROUGH) != 0;
 			styleRange.underline = (style & TextAttribute.UNDERLINE) != 0;
@@ -788,7 +788,7 @@ public class TMPresentationReconciler implements IPresentationReconciler {
 				field.trySetAccessible();
 				final Object presentationReconciler = field.get(textViewer);
 				// field is IPresentationRecounciler, looking for TMPresentationReconciler implementation
-				return presentationReconciler instanceof final TMPresentationReconciler tmPresentationReconciler 
+				return presentationReconciler instanceof final TMPresentationReconciler tmPresentationReconciler
 						? tmPresentationReconciler
 						: null;
 			}

--- a/org.eclipse.tm4e.ui/src/test/java/org/eclipse/tm4e/ui/internal/model/DocumentLineListTest.java
+++ b/org.eclipse.tm4e.ui/src/test/java/org/eclipse/tm4e/ui/internal/model/DocumentLineListTest.java
@@ -21,8 +21,8 @@ class DocumentLineListTest {
 
 	@Test
 	void testMultiLineChange() {
-		final Document document = new Document();
-		final DocumentLineList lineList = new DocumentLineList(document);
+		final var document = new Document();
+		final var lineList = new DocumentLineList(document);
 
 		document.set("a\nb\nc\nd");
 		assertEquals(4, lineList.getNumberOfLines());


### PR DESCRIPTION
I am using the var keyword in places where it does not decrease code comprehensibility and where the type of the declared variable is obvious.

I did not replace types with the var keyword where the values assigned are the results of chained method calls on some object because this increases cognitive load when reading/comprehending the code.