### PR TITLE
Replace non-functional stopAtOffset tokenize parameter with timeLimit

### DIFF
--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/grammar/IGrammar.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/grammar/IGrammar.java
@@ -16,6 +16,7 @@
  */
 package org.eclipse.tm4e.core.grammar;
 
+import java.time.Duration;
 import java.util.Collection;
 
 import org.eclipse.jdt.annotation.Nullable;
@@ -65,13 +66,13 @@ public interface IGrammar {
 	 *
 	 * @param lineText the line text to tokenize.
 	 * @param prevState previous line state.
-	 * @param timeLimit duration in milliseconds after which tokenization is aborted, in which case the returned result
+	 * @param timeLimit duration after which tokenization is aborted, in which case the returned result
 	 *        will have {@link ITokenizeLineResult#isStoppedEarly()} set to <code>true</code>
 	 *
 	 * @return the result of the tokenization.
 	 */
 	ITokenizeLineResult<IToken[]> tokenizeLine(String lineText, @Nullable IStateStack prevState,
-		@Nullable Integer timeLimit);
+		@Nullable Duration timeLimit);
 
 	/**
 	 * Tokenize `lineText` using previous line state `prevState`.
@@ -107,9 +108,9 @@ public interface IGrammar {
 	 *
 	 * @param lineText the line text to tokenize.
 	 * @param prevState previous line state.
-	 * @param timeLimit duration in milliseconds after which tokenization is aborted, in which case the returned result
+	 * @param timeLimit duration after which tokenization is aborted, in which case the returned result
 	 *        will have {@link ITokenizeLineResult#isStoppedEarly()} set to <code>true</code>
 	 */
 	ITokenizeLineResult<int[]> tokenizeLine2(String lineText, @Nullable IStateStack prevState,
-		@Nullable Integer timeLimit);
+		@Nullable Duration timeLimit);
 }

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/Grammar.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/Grammar.java
@@ -19,6 +19,7 @@ package org.eclipse.tm4e.core.internal.grammar;
 
 import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -256,8 +257,9 @@ public final class Grammar implements IGrammar, IRuleFactoryHelper {
 	}
 
 	@Override
-	public ITokenizeLineResult<IToken[]> tokenizeLine(final String lineText, @Nullable final IStateStack prevState,
-		@Nullable final Integer timeLimit) {
+	public ITokenizeLineResult<IToken[]> tokenizeLine(final String lineText,
+		@Nullable final IStateStack prevState,
+		@Nullable final Duration timeLimit) {
 		return _tokenize(lineText, (StateStack) prevState, false, timeLimit);
 	}
 
@@ -268,7 +270,7 @@ public final class Grammar implements IGrammar, IRuleFactoryHelper {
 
 	@Override
 	public ITokenizeLineResult<int[]> tokenizeLine2(final String lineText, @Nullable final IStateStack prevState,
-		@Nullable final Integer timeLimit) {
+		@Nullable final Duration timeLimit) {
 		return _tokenize(lineText, (StateStack) prevState, true, timeLimit);
 	}
 
@@ -277,7 +279,7 @@ public final class Grammar implements IGrammar, IRuleFactoryHelper {
 		String lineText,
 		@Nullable StateStack prevState,
 		final boolean emitBinaryTokens,
-		@Nullable final Integer timeLimit) {
+		@Nullable final Duration timeLimit) {
 		var rootId = this._rootId;
 		if (rootId == null) {
 			rootId = this._rootId = RuleFactory.getCompiledRuleId(
@@ -349,7 +351,7 @@ public final class Grammar implements IGrammar, IRuleFactoryHelper {
 			prevState,
 			lineTokens,
 			true,
-			timeLimit == null ? 0 : timeLimit);
+			timeLimit == null ? Duration.ZERO : timeLimit);
 
 		if (emitBinaryTokens) {
 			return (T) new TokenizeLineResult<>(lineTokens.getBinaryResult(tokenizeResult.stack, lineLength),

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/LineTokenizer.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/LineTokenizer.java
@@ -21,6 +21,7 @@ import static org.eclipse.tm4e.core.internal.utils.NullSafetyHelper.*;
 
 import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
+import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
@@ -111,7 +112,7 @@ final class LineTokenizer {
 		this.lineTokens = lineTokens;
 	}
 
-	private TokenizeStringResult scan(final boolean checkWhileConditions, final int timeLimit) {
+	private TokenizeStringResult scan(final boolean checkWhileConditions, final long timeLimit) {
 		stop = false;
 
 		if (checkWhileConditions) {
@@ -498,7 +499,7 @@ final class LineTokenizer {
 					nameScopesList, contentNameScopesList);
 				final var onigSubStr = OnigString.of(lineTextContent.substring(0, captureIndex.end));
 				tokenizeString(grammar, onigSubStr, isFirstLine && captureIndex.start == 0,
-					captureIndex.start, stackClone, lineTokens, false, /* no time limit */0);
+					captureIndex.start, stackClone, lineTokens, false, Duration.ZERO /* no time limit */);
 				continue;
 			}
 
@@ -586,9 +587,9 @@ final class LineTokenizer {
 	static TokenizeStringResult tokenizeString(final Grammar grammar, final OnigString lineText,
 		final boolean isFirstLine,
 		final int linePos, final StateStack stack, final LineTokens lineTokens,
-		final boolean checkWhileConditions, final int timeLimit) {
+		final boolean checkWhileConditions, final Duration timeLimit) {
 		return new LineTokenizer(grammar, lineText, isFirstLine, linePos, stack, lineTokens)
-			.scan(checkWhileConditions, timeLimit);
+			.scan(checkWhileConditions, timeLimit.toMillis());
 	}
 
 	static String debugCompiledRuleToString(final CompiledRule ruleScanner) {

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/model/ITokenizationSupport.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/model/ITokenizationSupport.java
@@ -16,6 +16,8 @@
  */
 package org.eclipse.tm4e.core.model;
 
+import java.time.Duration;
+
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tm4e.core.grammar.IStateStack;
 
@@ -29,9 +31,10 @@ public interface ITokenizationSupport {
 
 	TokenizationResult tokenize(String line, @Nullable IStateStack state);
 
-	// add offsetDelta to each of the returned indices
-	// stop tokenizing at absolute value stopAtOffset (i.e. stream.pos() +
-	// offsetDelta > stopAtOffset)
-	TokenizationResult tokenize(String line, @Nullable IStateStack state, Integer offsetDelta, Integer stopAtOffset);
-
+	/**
+	 * @param offsetDelta adds offsetDelta to each of the returned indices
+	 * @param timeLimit duration after which tokenization is stopped
+	 */
+	TokenizationResult tokenize(String line, @Nullable IStateStack state, @Nullable Integer offsetDelta,
+		@Nullable Duration timeLimit);
 }

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/model/TMModel.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/model/TMModel.java
@@ -16,6 +16,7 @@ import static org.eclipse.tm4e.core.internal.utils.MoreCollections.*;
 import static org.eclipse.tm4e.core.internal.utils.NullSafetyHelper.*;
 
 import java.lang.System.Logger;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -179,8 +180,8 @@ public class TMModel implements ITMModel {
 		 */
 		private int updateTokensInRange(final ModelTokensChangedEventBuilder eventBuilder, final int startIndex,
 			final int endLineIndex) {
-			final int stopLineTokenizationAfter = 1_000_000_000; // 1 billion, if a line is so long, you have other
-																 // trouble :)
+			final var stopLineTokenizationAfter = Duration.ofMillis(1_000_000_000); // 1 billion, if a line is so long,
+																					 // you have other trouble :)
 
 			// Validate all states up to and including endLineIndex
 			int nextInvalidLineIndex = startIndex;

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/model/TokenizationResult.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/model/TokenizationResult.java
@@ -25,7 +25,7 @@ import org.eclipse.tm4e.core.grammar.IStateStack;
  * @see <a href="https://github.com/microsoft/vscode/blob/main/src/vs/editor//common/languages.ts">
  *      github.com/microsoft/vscode/blob/main/src/vs/editor//common/languages.ts</a>
  */
-public class TokenizationResult {
+public final class TokenizationResult {
 
 	final List<TMToken> tokens;
 	int actualStopOffset;
@@ -33,10 +33,14 @@ public class TokenizationResult {
 	@Nullable
 	IStateStack endState;
 
-	public TokenizationResult(final List<TMToken> tokens, final int actualStopOffset, @Nullable final IStateStack endState) {
+	final boolean stoppedEarly;
+
+	public TokenizationResult(final List<TMToken> tokens, final int actualStopOffset,
+		@Nullable final IStateStack endState, final boolean stoppedEarly) {
 		this.tokens = tokens;
 		this.actualStopOffset = actualStopOffset;
 		this.endState = endState;
+		this.stoppedEarly = stoppedEarly;
 	}
 
 	@Nullable
@@ -46,5 +50,12 @@ public class TokenizationResult {
 
 	public List<TMToken> getTokens() {
 		return tokens;
+	}
+
+	/**
+	 * Did tokenization stop early due to reaching the time limit.
+	 */
+	public boolean isStoppedEarly() {
+		return stoppedEarly;
 	}
 }

--- a/org.eclipse.tm4e.core/src/test/java/org/eclipse/tm4e/core/grammar/GrammarTest.java
+++ b/org.eclipse.tm4e.core/src/test/java/org/eclipse/tm4e/core/grammar/GrammarTest.java
@@ -19,6 +19,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -246,7 +247,7 @@ class GrammarTest {
 			assertFalse(result1.isStoppedEarly());
 			final var lastToken1 = result1.getTokens()[result1.getTokens().length - 1];
 
-			final var result2 = grammar.tokenizeLine(veryLongLine, null, 10 /*ms timeLimit*/);
+			final var result2 = grammar.tokenizeLine(veryLongLine, null, Duration.ofMillis(10));
 			assertTrue(result2.isStoppedEarly());
 			assertNotEquals(result1.getTokens().length, result2.getTokens().length);
 			final var lastToken2 = result2.getTokens()[result2.getTokens().length - 1];

--- a/org.eclipse.tm4e.core/src/test/java/org/eclipse/tm4e/core/model/TMTokenizationTest.java
+++ b/org.eclipse.tm4e.core/src/test/java/org/eclipse/tm4e/core/model/TMTokenizationTest.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2022 Sebastian Thomschke and others.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.tm4e.core.model;
+
+import static org.eclipse.tm4e.core.registry.IGrammarSource.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.time.Duration;
+import java.util.stream.Collectors;
+
+import org.eclipse.tm4e.core.Data;
+import org.eclipse.tm4e.core.registry.Registry;
+import org.junit.jupiter.api.Test;
+
+class TMTokenizationTest {
+
+	@Test
+	void testTokenizeWithTimeout() throws IOException {
+		final var grammar = new Registry().addGrammar(fromResource(Data.class, "TypeScript.tmLanguage.json"));
+
+		final var tokenizer = new TMTokenization(grammar);
+		try (var reader = new BufferedReader(new InputStreamReader(Data.class.getResourceAsStream("raytracer.ts")))) {
+			final String veryLongLine = reader.lines().collect(Collectors.joining());
+			final var result1 = tokenizer.tokenize(veryLongLine, null);
+			assertFalse(result1.stoppedEarly);
+
+			final var result2 = tokenizer.tokenize(veryLongLine, null, null, Duration.ofMillis(10));
+			assertTrue(result2.stoppedEarly);
+
+			assertNotEquals(result1.tokens.size(), result2.tokens.size());
+		}
+	}
+}


### PR DESCRIPTION
The `stopAtOffset` parameter of `ITokenizationSupport#tokenize` was not implemented and the **tm4e.ui** plugin was not using it. So I replaced it with the `timeLimit` parameter which I already added to `IGrammar#tokenizeLine` according to the vscode-textmate project.

When this PR is merged I am going to work on the TMModel implementation. Having timeLimit support in ITokenizationSupport will allow to greatly simplify the TMModel class.