### PR TITLE
Respect notIn setting of AutoClosingPairs

### DIFF
--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/LanguageConfigurationRegistryManager.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/LanguageConfigurationRegistryManager.java
@@ -27,6 +27,7 @@ import org.eclipse.jface.text.IRegion;
 import org.eclipse.tm4e.languageconfiguration.ILanguageConfigurationDefinition;
 import org.eclipse.tm4e.languageconfiguration.internal.preferences.PreferenceConstants;
 import org.eclipse.tm4e.languageconfiguration.internal.preferences.PreferenceHelper;
+import org.eclipse.tm4e.languageconfiguration.internal.supports.AutoClosingPairConditional;
 import org.eclipse.tm4e.languageconfiguration.internal.supports.CharacterPair;
 import org.eclipse.tm4e.languageconfiguration.internal.supports.CharacterPairSupport;
 import org.eclipse.tm4e.languageconfiguration.internal.supports.CommentSupport;
@@ -79,13 +80,13 @@ public final class LanguageConfigurationRegistryManager extends AbstractLanguage
 	}
 
 	@Nullable
-	public CharacterPair getAutoClosePair(final String text, final int offset, final String newCharacter,
+	public AutoClosingPairConditional getAutoClosePair(final String text, final int offset, final String newCharacter,
 			final IContentType contentType) {
 		final var definition = getDefinition(contentType);
 		if (definition == null || !definition.isBracketAutoClosingEnabled()) {
 			return null;
 		}
-		final CharacterPairSupport characterPairSupport = this._getCharacterPairSupport(contentType);
+		final var characterPairSupport = this._getCharacterPairSupport(contentType);
 		return characterPairSupport == null ? null : characterPairSupport.getAutoClosePair(text, offset, newCharacter);
 	}
 
@@ -119,7 +120,7 @@ public final class LanguageConfigurationRegistryManager extends AbstractLanguage
 		return true;
 	}
 
-	public List<CharacterPair> getEnabledAutoClosingPairs(final IContentType contentType) {
+	public List<AutoClosingPairConditional> getEnabledAutoClosingPairs(final IContentType contentType) {
 		final var definition = getDefinition(contentType);
 		if (definition == null || !definition.isBracketAutoClosingEnabled()) {
 			return Collections.emptyList();

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/supports/AutoClosingPairConditional.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/supports/AutoClosingPairConditional.java
@@ -13,14 +13,11 @@ package org.eclipse.tm4e.languageconfiguration.internal.supports;
 
 import java.util.List;
 
-import org.eclipse.jdt.annotation.Nullable;
-
 public final class AutoClosingPairConditional extends CharacterPair {
 
-	@Nullable
 	public final List<String> notIn;
 
-	public AutoClosingPairConditional(final String open, final String close, @Nullable final List<String> notIn) {
+	public AutoClosingPairConditional(final String open, final String close, final List<String> notIn) {
 		super(open, close);
 		this.notIn = notIn;
 	}

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/supports/CharacterPairSupport.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/supports/CharacterPairSupport.java
@@ -11,7 +11,7 @@
  */
 package org.eclipse.tm4e.languageconfiguration.internal.supports;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -23,36 +23,38 @@ import org.eclipse.jdt.annotation.Nullable;
  */
 public final class CharacterPairSupport {
 
-	public final List<CharacterPair> autoClosingPairs;
+	public final List<AutoClosingPairConditional> autoClosingPairs;
 	public final List<CharacterPair> surroundingPairs;
 
+	@SuppressWarnings("unchecked")
 	public CharacterPairSupport(@Nullable final List<CharacterPair> brackets,
 			@Nullable final List<AutoClosingPairConditional> autoClosingPairs,
 			@Nullable final List<CharacterPair> surroundingPairs) {
+
 		if (autoClosingPairs != null) {
 			this.autoClosingPairs = autoClosingPairs.stream().filter(Objects::nonNull)
 					.map(el -> new AutoClosingPairConditional(el.open, el.close, el.notIn))
 					.collect(Collectors.toList());
 		} else if (brackets != null) {
 			this.autoClosingPairs = brackets.stream().filter(Objects::nonNull)
-					.map(el -> new AutoClosingPairConditional(el.open, el.close, null))
+					.map(el -> new AutoClosingPairConditional(el.open, el.close, Collections.emptyList()))
 					.collect(Collectors.toList());
 		} else {
-			this.autoClosingPairs = new ArrayList<>();
+			this.autoClosingPairs = Collections.emptyList();
 		}
 
 		this.surroundingPairs = surroundingPairs != null
 				? surroundingPairs.stream().filter(Objects::nonNull).collect(Collectors.toList())
-				: this.autoClosingPairs;
+				: (List<CharacterPair>) (List<?>) this.autoClosingPairs;
 	}
 
 	@Nullable
-	public CharacterPair getAutoClosePair(final String text, final int offset,
+	public AutoClosingPairConditional getAutoClosePair(final String text, final int offset,
 			final String newCharacter/* : string, context: ScopedLineTokens, column: number */) {
 		if (newCharacter.isEmpty()) {
 			return null;
 		}
-		for (final CharacterPair autoClosingPair : autoClosingPairs) {
+		for (final AutoClosingPairConditional autoClosingPair : autoClosingPairs) {
 			final String opening = autoClosingPair.open;
 			if (!opening.endsWith(newCharacter)) {
 				continue;

--- a/org.eclipse.tm4e.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.ui/META-INF/MANIFEST.MF
@@ -21,7 +21,7 @@ Require-Bundle: org.eclipse.tm4e.core;bundle-version="0.4.6",
  org.eclipse.ui.trace;resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.tm4e.ui,
- org.eclipse.tm4e.ui.internal.model;x-friends:="org.eclipse.tm4e.ui.tests",
+ org.eclipse.tm4e.ui.internal.model;x-friends:="org.eclipse.tm4e.languageconfiguration,org.eclipse.tm4e.ui.tests",
  org.eclipse.tm4e.ui.internal.themes;x-friends:="org.eclipse.tm4e.ui.tests",
  org.eclipse.tm4e.ui.internal.utils;x-friends:="org.eclipse.tm4e.ui.tests,org.eclipse.tm4e.languageconfiguration",
  org.eclipse.tm4e.ui.model,


### PR DESCRIPTION
This PR addresses https://github.com/eclipse/tm4e/issues/227

Since the logic relies on the asynchronously parsed line tokens it might not be 100% when typing very fast but I believe it is still better than nothing.