### PR TITLE
Refactor Eclipse logging

### DIFF
--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/LanguageConfigurationPlugin.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/LanguageConfigurationPlugin.java
@@ -12,6 +12,7 @@
 package org.eclipse.tm4e.languageconfiguration;
 
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
@@ -39,10 +40,20 @@ public final class LanguageConfigurationPlugin extends AbstractUIPlugin {
 	}
 
 	public static void log(final IStatus status) {
-		final var plugin = LanguageConfigurationPlugin.plugin;
-		if (plugin != null) {
-			plugin.getLog().log(status);
+		final var p = plugin;
+		if (p != null) {
+			p.getLog().log(status);
+		} else {
+			System.out.println(status);
 		}
+	}
+
+	public static void logError(final Exception ex) {
+		log(new Status(IStatus.ERROR, PLUGIN_ID, ex.getMessage(), ex));
+	}
+
+	public static void logError(final String message, @Nullable final Exception ex) {
+		log(new Status(IStatus.ERROR, PLUGIN_ID, message, ex));
 	}
 
 	@Override

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/preferences/LanguageConfigurationPreferencePage.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/preferences/LanguageConfigurationPreferencePage.java
@@ -43,6 +43,7 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
+import org.eclipse.tm4e.languageconfiguration.LanguageConfigurationPlugin;
 import org.eclipse.tm4e.languageconfiguration.internal.registry.ILanguageConfigurationDefinition;
 import org.eclipse.tm4e.languageconfiguration.internal.registry.ILanguageConfigurationRegistryManager;
 import org.eclipse.tm4e.languageconfiguration.internal.registry.LanguageConfigurationRegistryManager;
@@ -279,8 +280,8 @@ public final class LanguageConfigurationPreferencePage extends PreferencePage im
 	public boolean performOk() {
 		try {
 			manager.save();
-		} catch (final BackingStoreException e) {
-			// TODO: Log
+		} catch (final BackingStoreException ex) {
+			LanguageConfigurationPlugin.logError(ex);
 		}
 		return super.performOk();
 	}

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/preferences/PreferenceHelper.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/preferences/PreferenceHelper.java
@@ -15,8 +15,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Objects;
 
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.tm4e.languageconfiguration.LanguageConfigurationPlugin;
 import org.eclipse.tm4e.languageconfiguration.internal.registry.ILanguageConfigurationDefinition;
@@ -44,9 +42,9 @@ public final class PreferenceHelper {
 						final var contentTypeId = object.get("contentTypeId").getAsString();
 						final var contentType = ContentTypeHelper.getContentTypeById(contentTypeId);
 						if (contentType == null) {
-							LanguageConfigurationPlugin.log(new Status(IStatus.ERROR, PreferenceHelper.class,
-									"Cannot load language configuration with unknown content type ID "
-											+ contentTypeId));
+							LanguageConfigurationPlugin.logError(
+									"Cannot load language configuration with unknown content type ID " + contentTypeId,
+									null);
 							return null;
 						}
 						return new LanguageConfigurationDefinition(contentType, // $NON-NLS-1$

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/registry/LanguageConfigurationDefinition.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/registry/LanguageConfigurationDefinition.java
@@ -136,12 +136,8 @@ public final class LanguageConfigurationDefinition extends TMResource implements
 	public ILanguageConfiguration getLanguageConfiguration() {
 		try (var in = getInputStream()) {
 			return LanguageConfiguration.load(new InputStreamReader(in, Charset.defaultCharset()));
-		} catch (final IOException e) {
-			final var plugin = LanguageConfigurationPlugin.getDefault();
-			if (plugin != null) {
-				plugin.getLog().log(
-						new Status(IStatus.ERROR, LanguageConfigurationPlugin.PLUGIN_ID, e.getMessage(), e));
-			}
+		} catch (final IOException ex) {
+			LanguageConfigurationPlugin.logError(ex);
 			return null;
 		}
 	}

--- a/org.eclipse.tm4e.registry/.options
+++ b/org.eclipse.tm4e.registry/.options
@@ -1,1 +1,0 @@
-org.eclipse.tm4e.registry/debug/log/Grammar = false

--- a/org.eclipse.tm4e.registry/build.properties
+++ b/org.eclipse.tm4e.registry/build.properties
@@ -5,7 +5,6 @@ bin.includes = META-INF/,\
                plugin.xml,\
                plugin.properties,\
                .,\
-               .options,\
                about.html
 
 # https://codeiseasy.wordpress.com/2013/03/08/tycho-and-jdt-null-analysis/

--- a/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/TMEclipseRegistryPlugin.java
+++ b/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/TMEclipseRegistryPlugin.java
@@ -1,45 +1,72 @@
 /**
- *  Copyright (c) 2015-2017 Angelo ZERR.
+ * Copyright (c) 2015-2017 Angelo ZERR.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
  *
- *  Contributors:
- *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
+ * Contributors:
+ * Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
  */
 package org.eclipse.tm4e.registry;
 
-import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Plugin;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tm4e.registry.internal.GrammarRegistryManager;
-import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 
 /**
  * OSGi Activator for TextMate Eclipse registry bundle.
  */
-public class TMEclipseRegistryPlugin implements BundleActivator {
+public class TMEclipseRegistryPlugin extends Plugin {
 
+	/** The plug-in ID */
 	public static final String PLUGIN_ID = "org.eclipse.tm4e.registry";
 
+	/** The shared instance */
 	@Nullable
-	private static BundleContext context;
+	private static volatile TMEclipseRegistryPlugin plugin;
 
+	/**
+	 * Returns the shared instance
+	 *
+	 * @return the shared instance
+	 */
 	@Nullable
-	static BundleContext getContext() {
-		return context;
+	public static TMEclipseRegistryPlugin getDefault() {
+		return plugin;
+	}
+
+	public static void log(final IStatus status) {
+		final var p = plugin;
+		if (p != null) {
+			p.getLog().log(status);
+		} else {
+			System.out.println(status);
+		}
+	}
+
+	public static void logError(final Exception ex) {
+		log(new Status(IStatus.ERROR, PLUGIN_ID, ex.getMessage(), ex));
+	}
+
+	public static void logError(final String message, @Nullable final Exception ex) {
+		log(new Status(IStatus.ERROR, PLUGIN_ID, message, ex));
 	}
 
 	@Override
 	public void start(@Nullable final BundleContext bundleContext) throws Exception {
-		TMEclipseRegistryPlugin.context = bundleContext;
+		super.start(bundleContext);
+		plugin = this;
 	}
 
 	@Override
 	public void stop(@Nullable final BundleContext bundleContext) throws Exception {
-		TMEclipseRegistryPlugin.context = null;
+		plugin = null;
+		super.stop(bundleContext);
 	}
 
 	/**
@@ -49,17 +76,5 @@ public class TMEclipseRegistryPlugin implements BundleActivator {
 	 */
 	public static IGrammarRegistryManager getGrammarRegistryManager() {
 		return GrammarRegistryManager.getInstance();
-	}
-
-	/**
-	 * Returns true if the debug option is enabled and false otherwise.
-	 *
-	 * @param option
-	 *            the option name
-	 * @return true if the debug option is enabled and false otherwise.
-	 */
-	public static boolean isDebugOptionEnabled(final String option) {
-		final String enabled = Platform.getDebugOption(option);
-		return enabled != null && Boolean.parseBoolean(enabled);
 	}
 }

--- a/org.eclipse.tm4e.ui/.options
+++ b/org.eclipse.tm4e.ui/.options
@@ -1,5 +1,3 @@
 org.eclipse.tm4e.ui/debug/log/GenerateTest = false
-org.eclipse.tm4e.ui/debug/log/TMPresentationReconciler = false
 org.eclipse.tm4e.ui/debug/log/ThrowError = false
-org.eclipse.tm4e.ui/debug/log/TMModelManager = false
 org.eclipse.tm4e.ui/trace = false

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/model/DocumentModelLines.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/model/DocumentModelLines.java
@@ -11,8 +11,6 @@
  */
 package org.eclipse.tm4e.ui.internal.model;
 
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.DocumentEvent;
@@ -50,7 +48,7 @@ final class DocumentModelLines extends AbstractModelLines implements IDocumentLi
 			default:
 			}
 		} catch (final BadLocationException ex) {
-			TMUIPlugin.log(new Status(IStatus.ERROR, TMUIPlugin.PLUGIN_ID, ex.getMessage(), ex));
+			TMUIPlugin.logError(ex);
 		}
 	}
 
@@ -86,7 +84,7 @@ final class DocumentModelLines extends AbstractModelLines implements IDocumentLi
 			}
 			}
 		} catch (final BadLocationException ex) {
-			TMUIPlugin.log(new Status(IStatus.ERROR, TMUIPlugin.PLUGIN_ID, ex.getMessage(), ex));
+			TMUIPlugin.logError(ex);
 		}
 	}
 

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/preferences/ThemePreferencePage.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/preferences/ThemePreferencePage.java
@@ -18,8 +18,6 @@ import static org.eclipse.tm4e.core.internal.utils.NullSafetyHelper.*;
 
 import java.io.File;
 
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.layout.TableColumnLayout;
@@ -378,8 +376,8 @@ public final class ThemePreferencePage extends PreferencePage implements IWorkbe
 			themeManager.save();
 			grammarRegistryManager.save();
 			return true;
-		} catch (final BackingStoreException e) {
-			TMUIPlugin.log(new Status(IStatus.ERROR, TMUIPlugin.PLUGIN_ID, e.getMessage(), e));
+		} catch (final BackingStoreException ex) {
+			TMUIPlugin.logError(ex);
 			return false;
 		}
 	}

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/utils/MarkerUtils.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/utils/MarkerUtils.java
@@ -73,7 +73,7 @@ public final class MarkerUtils {
 			try {
 				updateTextMarkers(docModel, event.ranges.get(0).fromLineNumber);
 			} catch (final CoreException ex) {
-				TMUIPlugin.log(new Status(IStatus.ERROR, TMUIPlugin.PLUGIN_ID, ex.getMessage(), ex));
+				TMUIPlugin.logError(ex);
 			}
 		}
 	}
@@ -164,7 +164,7 @@ public final class MarkerUtils {
 						res.createMarker(markerConfig.type, attrs);
 					}
 				} catch (final Exception ex) {
-					TMUIPlugin.log(new Status(IStatus.ERROR, TMUIPlugin.PLUGIN_ID, ex.getMessage(), ex));
+					TMUIPlugin.logError(ex);
 				}
 			}
 
@@ -184,7 +184,7 @@ public final class MarkerUtils {
 			if (lineNumberAttr instanceof final Integer lineNumber)
 				return lineNumber;
 		} catch (final CoreException ex) {
-			TMUIPlugin.log(new Status(IStatus.ERROR, TMUIPlugin.PLUGIN_ID, ex.getMessage(), ex));
+			TMUIPlugin.logError(ex);
 		}
 		return null;
 	}

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/utils/PreferenceUtils.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/utils/PreferenceUtils.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.tm4e.ui.internal.utils;
 
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.jdt.annotation.Nullable;
@@ -23,7 +24,12 @@ public final class PreferenceUtils {
 	private static final String E4_CSS_PREFERENCE_NAME = "org.eclipse.e4.ui.css.swt.theme"; //$NON-NLS-1$
 	private static final String EDITORS_PREFERENCE_NAME = "org.eclipse.ui.editors"; //$NON-NLS-1$
 
-	private PreferenceUtils() {
+	public static boolean isDebugGenerateTest() {
+		return Boolean.parseBoolean(Platform.getDebugOption(TMUIPlugin.PLUGIN_ID + "/debug/log/GenerateTest"));
+	}
+
+	public static boolean isDebugThrowError() {
+		return Boolean.parseBoolean(Platform.getDebugOption(TMUIPlugin.PLUGIN_ID + "/debug/log/ThrowError"));
 	}
 
 	/**
@@ -66,5 +72,8 @@ public final class PreferenceUtils {
 	public static IPreferenceStore getTM4EPreferencesStore() {
 		final var plugin = TMUIPlugin.getDefault();
 		return plugin == null ? null : plugin.getPreferenceStore();
+	}
+
+	private PreferenceUtils() {
 	}
 }

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/themes/css/CSSTokenProvider.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/themes/css/CSSTokenProvider.java
@@ -15,8 +15,6 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jface.text.TextAttribute;
 import org.eclipse.jface.text.rules.IToken;
@@ -64,8 +62,8 @@ public class CSSTokenProvider extends AbstractTokenProvider {
 							new Token(new TextAttribute(ColorManager.getInstance().getColor(color), null, s)));
 				}
 			}
-		} catch (final Exception e) {
-			TMUIPlugin.log(new Status(IStatus.ERROR, TMUIPlugin.PLUGIN_ID, e.getMessage(), e));
+		} catch (final Exception ex) {
+			TMUIPlugin.logError(ex);
 		}
 	}
 


### PR DESCRIPTION
1. This PR mainly gets rid of all the repetitive log statements like
    ```java
    TMUIPlugin.log(new Status(IStatus.ERROR, TMUIPlugin.PLUGIN_ID, ex.getMessage(), ex));
    ```
1. I also removed the very generic `TMEclipseRegistryPlugin.isDebugOptionEnabled` method, which strangely was only used by the TM4E UI Plugin.
1. Additionally I removed some unused parameters from `.options` files.
