### PR TITLE
Downgrade gson to 2.8.9

### DIFF
--- a/org.eclipse.tm4e.core.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.core.tests/META-INF/MANIFEST.MF
@@ -4,10 +4,10 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tm4e.core.tests;singleton:=true
-Bundle-Version: 0.5.0.qualifier
+Bundle-Version: 0.5.1.qualifier
 Require-Bundle: org.apache.batik.css;bundle-version="1.7.0";resolution:=optional,
  org.apache.batik.util;bundle-version="1.7.0";resolution:=optional,
- com.google.gson;bundle-version="2.9.0";resolution:=optional,
+ com.google.gson;bundle-version="2.8.9";resolution:=optional,
  org.eclipse.core.runtime,
  org.eclipse.tm4e.core
 Import-Package: org.junit.runner,

--- a/org.eclipse.tm4e.core.tests/pom.xml
+++ b/org.eclipse.tm4e.core.tests/pom.xml
@@ -10,7 +10,7 @@
 
 	<artifactId>org.eclipse.tm4e.core.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
-	<version>0.5.0-SNAPSHOT</version>
+	<version>0.5.1-SNAPSHOT</version>
 
 	<build>
 		<pluginManagement>

--- a/org.eclipse.tm4e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.core/META-INF/MANIFEST.MF
@@ -4,10 +4,10 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tm4e.core
-Bundle-Version: 0.5.0.qualifier
+Bundle-Version: 0.5.1.qualifier
 Require-Bundle: org.apache.batik.css;bundle-version="1.9.1";resolution:=optional,
  org.apache.batik.util;bundle-version="1.9.1";resolution:=optional,
- com.google.gson;bundle-version="2.9.0",
+ com.google.gson;bundle-version="2.8.9",
  com.google.guava;bundle-version="30.1.0",
  org.jcodings;bundle-version="1.0.57",
  org.joni;bundle-version="2.1.43",

--- a/org.eclipse.tm4e.core/pom.xml
+++ b/org.eclipse.tm4e.core/pom.xml
@@ -10,7 +10,7 @@
 
 	<artifactId>org.eclipse.tm4e.core</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.5.0-SNAPSHOT</version>
+	<version>0.5.1-SNAPSHOT</version>
 
 	<profiles>
 		<profile>

--- a/org.eclipse.tm4e.languageconfiguration/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.languageconfiguration/META-INF/MANIFEST.MF
@@ -8,9 +8,9 @@ Bundle-Version: 0.5.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.jface.text,
  org.eclipse.ui.genericeditor,
- com.google.gson;bundle-version="2.9.0",
- org.eclipse.tm4e.core;bundle-version="0.5.0",
- org.eclipse.tm4e.ui;bundle-version="0.6.0",
+ com.google.gson;bundle-version="2.8.9",
+ org.eclipse.tm4e.core;bundle-version="0.5.1",
+ org.eclipse.tm4e.ui;bundle-version="0.6.1",
  org.eclipse.core.runtime,
  org.eclipse.core.resources,
  org.eclipse.ui,

--- a/org.eclipse.tm4e.registry/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.registry/META-INF/MANIFEST.MF
@@ -3,11 +3,11 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.tm4e.registry;singleton:=true
-Bundle-Version: 0.6.0.qualifier
+Bundle-Version: 0.6.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Require-Bundle: org.eclipse.tm4e.core;bundle-version="0.5.0",
+Require-Bundle: org.eclipse.tm4e.core;bundle-version="0.5.1",
  org.eclipse.core.runtime,
- com.google.gson;bundle-version="2.9.0",
+ com.google.gson;bundle-version="2.8.9",
  com.google.guava;bundle-version="30.1.0",
  org.eclipse.equinox.preferences
 Export-Package: org.eclipse.tm4e.registry

--- a/org.eclipse.tm4e.registry/pom.xml
+++ b/org.eclipse.tm4e.registry/pom.xml
@@ -10,5 +10,5 @@
 
 	<artifactId>org.eclipse.tm4e.registry</artifactId>
 	<packaging>eclipse-plugin</packaging>
-			<version>0.6.0-SNAPSHOT</version>
+	<version>0.6.1-SNAPSHOT</version>
 </project>

--- a/org.eclipse.tm4e.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.ui.tests/META-INF/MANIFEST.MF
@@ -4,14 +4,14 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tm4e.ui.tests;singleton:=true
-Bundle-Version: 0.6.0.qualifier
+Bundle-Version: 0.6.1.qualifier
 Require-Bundle: org.eclipse.tm4e.core,
  org.eclipse.jface.text,
  org.eclipse.core.runtime,
  org.eclipse.ui,
  org.eclipse.core.resources,
  org.eclipse.core.filesystem,
- com.google.gson;bundle-version="2.9.0",
+ com.google.gson;bundle-version="2.8.9",
  org.eclipse.tm4e.ui,
  org.junit,
  org.junit.jupiter.api,

--- a/org.eclipse.tm4e.ui.tests/pom.xml
+++ b/org.eclipse.tm4e.ui.tests/pom.xml
@@ -10,7 +10,7 @@
 
 	<artifactId>org.eclipse.tm4e.ui.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
-	<version>0.6.0-SNAPSHOT</version>
+	<version>0.6.1-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.tm4e.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.ui/META-INF/MANIFEST.MF
@@ -4,16 +4,16 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tm4e.ui;singleton:=true
-Bundle-Version: 0.6.0.qualifier
-Require-Bundle: org.eclipse.tm4e.core;bundle-version="0.5.0",
+Bundle-Version: 0.6.1.qualifier
+Require-Bundle: org.eclipse.tm4e.core;bundle-version="0.5.1",
  org.eclipse.jface.text,
  org.eclipse.core.runtime,
  org.eclipse.ui,
  org.eclipse.core.resources,
  org.eclipse.core.filesystem,
- org.eclipse.tm4e.registry;bundle-version="0.6.0",
+ org.eclipse.tm4e.registry;bundle-version="0.6.1",
  org.eclipse.ui.ide;resolution:=optional,
- com.google.gson;bundle-version="2.9.0",
+ com.google.gson;bundle-version="2.8.9",
  com.google.guava,
  org.eclipse.e4.ui.css.swt.theme,
  org.eclipse.core.expressions,

--- a/org.eclipse.tm4e.ui/pom.xml
+++ b/org.eclipse.tm4e.ui/pom.xml
@@ -10,5 +10,5 @@
 
 	<artifactId>org.eclipse.tm4e.ui</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.6.0-SNAPSHOT</version>
+	<version>0.6.1-SNAPSHOT</version>
 </project>

--- a/target-platform/tm4e-target.target
+++ b/target-platform/tm4e-target.target
@@ -10,6 +10,7 @@
             <unit id="com.google.guava" version="30.1.0.v20210127-2300"/>
             <unit id="org.apache.batik.css" version="1.14.0.v20210324-0332"/>
             <unit id="org.yaml.snakeyaml" version="1.27.0.v20201111-1638"/>
+            <unit id="com.google.gson" version="2.8.9.v20220111-1409"/>
             <repository location="https://download.eclipse.org/tools/orbit/downloads/latest-S/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
@@ -25,23 +26,13 @@
         <location includeDependencyDepth="direct" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
             <dependencies>
                 <dependency>
-                    <groupId>com.google.code.gson</groupId>
-                    <artifactId>gson</artifactId>
-                    <version>2.9.0</version>
+                    <groupId>org.jruby.joni</groupId>
+                    <artifactId>joni</artifactId>
+                    <version>2.1.43</version>
                     <type>jar</type>
                 </dependency>
             </dependencies>
-        </location>
-	    <location includeDependencyDepth="direct" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
-		    <dependencies>
-			    <dependency>
-				    <groupId>org.jruby.joni</groupId>
-				    <artifactId>joni</artifactId>
-				    <version>2.1.43</version>
-				    <type>jar</type>
-			    </dependency>
-		    </dependencies>
-		    <instructions><![CDATA[
+            <instructions><![CDATA[
 Bundle-Name:           Bundle derived from maven artifact ${mvnGroupId}:${mvnArtifactId}:${mvnVersion}
 version:               ${version_cleanup;${mvnVersion}}
 Bundle-SymbolicName:   org.${mvnArtifactId}
@@ -50,7 +41,7 @@ Import-Package:        *;resolution:=optional
 Export-Package:        *;version="${version}";-noimport:=true
 DynamicImport-Package: *
 ]]></instructions>
-	    </location>
+        </location>
     </locations>
     <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 </target>


### PR DESCRIPTION
In the last release we/I upgraded gson to 2.9.0. The upgrade was not done for a functional reason but for working with the latest bugfix release.

Doing so however seems to somehow break dependency resolution in tycho builds of plugins that depend on TM4E and on another plugin that requires gson exactly in version 2.8.9.

For example after upgrading the dependency to TM4E 0.5.0 of an eclipse plugin that also depends on the latest LSP4E, tycho builds suddenly fail claiming gson 2.8.9 is not resolvable even though it is provided by the configured LSP4E p2 repository.
```python
[ERROR] Failed to execute goal org.eclipse.tycho:tycho-compiler-plugin:2.7.3:validate-classpath (default-validate-classpath) on project org.haxe4e: Execution default-validate-classpath of goal org.eclipse.tycho:tycho-compiler-plugin:2.7.3:validate-classpath failed: org.osgi.framework.BundleException: Bundle org.haxe4e cannot be resolved:org.haxe4e [143]
[ERROR]   Unresolved requirement: Require-Bundle: org.eclipse.lsp4e
[ERROR]     -> Bundle-SymbolicName: org.eclipse.lsp4e; bundle-version="0.13.12.202206011407"; singleton:="true"
[ERROR]        org.eclipse.lsp4e [112]
[ERROR]          Unresolved requirement: Require-Bundle: org.eclipse.lsp4j.jsonrpc; bundle-version="[0.14.0,0.15.0)"
[ERROR]            -> Bundle-SymbolicName: org.eclipse.lsp4j.jsonrpc; bundle-version="0.14.0.v20220526-1518"
[ERROR]               org.eclipse.lsp4j.jsonrpc [116]
[ERROR]                 Unresolved requirement: Import-Package: com.google.gson; version="[2.8.9,2.9.0)"
[ERROR]          Unresolved requirement: Require-Bundle: org.eclipse.lsp4j; bundle-version="[0.14.0,0.15.0)"
[ERROR]            -> Bundle-SymbolicName: org.eclipse.lsp4j; bundle-version="0.14.0.v20220526-1518"
[ERROR]               org.eclipse.lsp4j [115]
[ERROR]                 Unresolved requirement: Import-Package: com.google.gson; version="[2.8.9,2.9.0)"
[ERROR]
[ERROR] -> [Help 1]
```

Interestingly, directly building in Eclipse IDE and even launch the plugins works just fine.

Since we have no functional requirement for gson 2.9.0 I would like to downgrade the dependency to 2.8.9 for the time being.
