### PR TITLE
Use the inner parent as SWT parent in UI language configuration preference

### DIFF
--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/preferences/LanguageConfigurationPreferencePage.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/preferences/LanguageConfigurationPreferencePage.java
@@ -97,12 +97,12 @@ public final class LanguageConfigurationPreferencePage extends PreferencePage im
 		gd.horizontalSpan = 2;
 		innerParent.setLayoutData(gd);
 
-		createDefinitionsListContent(parent);
+		createDefinitionsListContent(innerParent);
 
 		assert definitionViewer != null;
 		definitionViewer.setInput(manager);
 
-		final var infoWidget = new LanguageConfigurationPreferencesWidget(parent, SWT.NONE);
+		final var infoWidget = new LanguageConfigurationPreferencesWidget(innerParent, SWT.NONE);
 		this.infoWidget = infoWidget;
 
 		final var data = new GridData(GridData.FILL_HORIZONTAL);


### PR DESCRIPTION
Use the inner parent as SWT parent in UI language configuration preference

Signed-off-by: azerr <azerr@redhat.com>