### PR TITLE
Fix syntax colouring when inline comments contain multi-byte characters + numerical constants/punctuation

### DIFF
--- a/org.eclipse.tm4e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tm4e.core
-Bundle-Version: 0.5.0.qualifier
+Bundle-Version: 0.5.1.qualifier
 Require-Bundle: org.apache.batik.css;bundle-version="1.9.1";resolution:=optional,
  org.apache.batik.util;bundle-version="1.9.1";resolution:=optional,
  com.google.gson;bundle-version="2.9.0",

--- a/org.eclipse.tm4e.core/pom.xml
+++ b/org.eclipse.tm4e.core/pom.xml
@@ -10,7 +10,7 @@
 
 	<artifactId>org.eclipse.tm4e.core</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.5.0-SNAPSHOT</version>
+	<version>0.5.1-SNAPSHOT</version>
 
 	<profiles>
 		<profile>

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/LineTokenizer.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/LineTokenizer.java
@@ -140,7 +140,7 @@ final class LineTokenizer {
 		if (r == null) {
 			LOGGER.log(TRACE, " no more matches.");
 			// No match
-			lineTokens.produce(stack, lineText.bytesCount);
+			lineTokens.produce(stack, lineText.content.length());
 			stop = true;
 			return;
 		}
@@ -179,7 +179,7 @@ final class LineTokenizer {
 				// intent was to continue in this state
 				stack = popped;
 
-				lineTokens.produce(stack, lineText.bytesCount);
+				lineTokens.produce(stack, lineText.content.length());
 				stop = true;
 				return;
 			}
@@ -199,7 +199,7 @@ final class LineTokenizer {
 				matchedRuleId,
 				linePos,
 				anchorPosition,
-				captureIndices[0].end == lineText.bytesCount,
+				captureIndices[0].end == lineText.content.length(),
 				null,
 				nameScopesList,
 				nameScopesList);
@@ -240,7 +240,7 @@ final class LineTokenizer {
 					LOGGER.log(INFO,
 						"[2] - Grammar is in an endless loop - Grammar pushed the same rule without advancing");
 					stack = castNonNull(stack.pop());
-					lineTokens.produce(stack, lineText.bytesCount);
+					lineTokens.produce(stack, lineText.content.length());
 					stop = true;
 					return;
 				}
@@ -279,7 +279,7 @@ final class LineTokenizer {
 					LOGGER.log(INFO,
 						"[3] - Grammar is in an endless loop - Grammar pushed the same rule without advancing");
 					stack = castNonNull(stack.pop());
-					lineTokens.produce(stack, lineText.bytesCount);
+					lineTokens.produce(stack, lineText.content.length());
 					stop = true;
 					return;
 				}
@@ -308,7 +308,7 @@ final class LineTokenizer {
 					LOGGER.log(INFO,
 						"[4] - Grammar is in an endless loop - Grammar is not advancing, nor is it pushing/popping");
 					stack = stack.safePop();
-					lineTokens.produce(stack, lineText.bytesCount);
+					lineTokens.produce(stack, lineText.content.length());
 					stop = true;
 					return;
 				}

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/oniguruma/OnigString.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/oniguruma/OnigString.java
@@ -55,7 +55,7 @@ public abstract class OnigString {
 		int getByteIndexOfChar(final int charIndex) {
 			if (charIndex == lastCharIndex + 1) {
 				// One off can happen when finding the end of a regexp (it's the right boundary).
-				return lastCharIndex + 1;
+				return bytesCount;
 			}
 
 			if (charIndex < 0 || charIndex > lastCharIndex) {

--- a/org.eclipse.tm4e.core/src/test/java/org/eclipse/tm4e/core/internal/grammar/TokenizeLineTest.java
+++ b/org.eclipse.tm4e.core/src/test/java/org/eclipse/tm4e/core/internal/grammar/TokenizeLineTest.java
@@ -1,5 +1,7 @@
 package org.eclipse.tm4e.core.internal.grammar;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.tm4e.core.Data;
 import org.eclipse.tm4e.core.registry.IGrammarSource;
 import org.eclipse.tm4e.core.registry.Registry;
@@ -11,7 +13,10 @@ public class TokenizeLineTest {
 	void testTokenizeLine2() throws Exception {
 		final var grammar = new Registry().addGrammar(IGrammarSource.fromResource(Data.class, "JavaScript.tmLanguage"));
 
-		final var lineTokens = grammar.tokenizeLine("function add(a,b) { return a+b; }");
+		final var lineText = new String("function add(a,b) { return a+b; }");
+		System.out.println(lineText);
+		
+		final var lineTokens = grammar.tokenizeLine(lineText);
 		for (int i = 0; i < lineTokens.getTokens().length; i++) {
 			final var token = lineTokens.getTokens()[i];
 			final var s = "Token from " + token.getStartIndex() + " to " + token.getEndIndex() + " with scopes "
@@ -21,10 +26,41 @@ public class TokenizeLineTest {
 
 		System.out.println("----------");
 
-		final var lineTokens2 = grammar.tokenizeLine2("function add(a,b) { return a+b; }");
+		final var lineTokens2 = grammar.tokenizeLine2(lineText);
 		for (int i = 0; i < lineTokens2.getTokens().length; i++) {
 			final int token = lineTokens2.getTokens()[i];
 			System.out.println(token);
 		}
+
+		System.out.println("----------");
+	}
+
+	@Test
+	void testTokenizeMultiByteLine2() throws Exception {
+		final var grammar = new Registry().addGrammar(IGrammarSource.fromResource(Data.class, "c.tmLanguage.json"));
+
+		final var lineText = new String("char cat[] = {\"кошка\"}; char mouse = -1;\n");
+		System.out.println(lineText);
+		
+		final var lineTokens = grammar.tokenizeLine("char cat[] = {\"кошка\"}; char mouse = -1;\n");
+		
+		for (int i = 0; i < lineTokens.getTokens().length; i++) {
+			final var token = lineTokens.getTokens()[i];
+			final var s = "Token from " + token.getStartIndex() + " to " + token.getEndIndex() + " with scopes "
+				+ token.getScopes();
+			assertTrue(token.getStartIndex() >=0 && token.getStartIndex() <= lineText.length() &&
+				token.getEndIndex() >=0 && token.getEndIndex() <= lineText.length());
+			System.out.println(s);
+		}
+
+		System.out.println("----------");
+
+		final var lineTokens2 = grammar.tokenizeLine2(lineText);
+		for (int i = 0; i < lineTokens2.getTokens().length; i++) {
+			final int token = lineTokens2.getTokens()[i];
+			System.out.println(token);
+		}
+
+		System.out.println("----------");
 	}
 }

--- a/org.eclipse.tm4e.core/src/test/java/org/eclipse/tm4e/core/internal/oniguruma/OnigStringTest.java
+++ b/org.eclipse.tm4e.core/src/test/java/org/eclipse/tm4e/core/internal/oniguruma/OnigStringTest.java
@@ -82,6 +82,7 @@ class OnigStringTest {
 		 * getByteIndexOfChar tests
 		 */
 		assertEquals(2, onigString.getByteIndexOfChar(1));
+		assertEquals(4, onigString.getByteIndexOfChar(2)); // this is an internal workaround
 
 		/*
 		 * getCharIndexOfByte tests
@@ -89,7 +90,7 @@ class OnigStringTest {
 		assertEquals(0, onigString.getCharIndexOfByte(1)); // á
 		assertEquals(1, onigString.getCharIndexOfByte(2)); // é
 		assertEquals(1, onigString.getCharIndexOfByte(3)); // é
-		assertEquals(2, onigString.getCharIndexOfByte(4)); // this is an internal workaround
+		assertEquals(2, onigString.getCharIndexOfByte(4)); // explicit test for an internal workaround
 		assertThrows(ArrayIndexOutOfBoundsException.class, () -> onigString.getCharIndexOfByte(5));
 
 	}
@@ -111,6 +112,7 @@ class OnigStringTest {
 		assertEquals(8, onigString.getByteIndexOfChar(5));
 		assertEquals(10, onigString.getByteIndexOfChar(6));
 		assertEquals(12, onigString.getByteIndexOfChar(7));
+		assertEquals(19, onigString.getByteIndexOfChar(12)); // this is an internal workaround
 
 		/*
 		 * getCharIndexOfByte tests
@@ -128,7 +130,7 @@ class OnigStringTest {
 		assertEquals(10, onigString.getCharIndexOfByte(17)); // a
 		assertEquals(11, onigString.getCharIndexOfByte(18)); // b
 
-		assertEquals(12, onigString.getCharIndexOfByte(19)); // this is an internal workaround
+		assertEquals(12, onigString.getCharIndexOfByte(19)); // explicit test for an internal workaround
 		assertThrows(ArrayIndexOutOfBoundsException.class, () -> onigString.getCharIndexOfByte(20));
 	}
 }

--- a/org.eclipse.tm4e.core/src/test/resources/org/eclipse/tm4e/core/c.tmLanguage.json
+++ b/org.eclipse.tm4e.core/src/test/resources/org/eclipse/tm4e/core/c.tmLanguage.json
@@ -1,0 +1,3127 @@
+{
+	"information_for_contributors": [
+		"This file has been converted from https://github.com/jeff-hykin/cpp-textmate-grammar/blob/master/syntaxes/c.tmLanguage.json",
+		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
+		"Once accepted there, we are happy to receive an update request."
+	],
+	"version": "https://github.com/jeff-hykin/cpp-textmate-grammar/commit/0ef79f098ed80ce5a86be4ed40f99ebcdbac4895",
+	"name": "C",
+	"scopeName": "source.c",
+	"patterns": [
+		{
+			"include": "#preprocessor-rule-enabled"
+		},
+		{
+			"include": "#preprocessor-rule-disabled"
+		},
+		{
+			"include": "#preprocessor-rule-conditional"
+		},
+		{
+			"include": "#predefined_macros"
+		},
+		{
+			"include": "#comments"
+		},
+		{
+			"include": "#switch_statement"
+		},
+		{
+			"match": "\\b(break|continue|do|else|for|goto|if|_Pragma|return|while)\\b",
+			"name": "keyword.control.c"
+		},
+		{
+			"include": "#storage_types"
+		},
+		{
+			"match": "typedef",
+			"name": "keyword.other.typedef.c"
+		},
+		{
+			"match": "\\b(const|extern|register|restrict|static|volatile|inline)\\b",
+			"name": "storage.modifier.c"
+		},
+		{
+			"match": "\\bk[A-Z]\\w*\\b",
+			"name": "constant.other.variable.mac-classic.c"
+		},
+		{
+			"match": "\\bg[A-Z]\\w*\\b",
+			"name": "variable.other.readwrite.global.mac-classic.c"
+		},
+		{
+			"match": "\\bs[A-Z]\\w*\\b",
+			"name": "variable.other.readwrite.static.mac-classic.c"
+		},
+		{
+			"match": "\\b(NULL|true|false|TRUE|FALSE)\\b",
+			"name": "constant.language.c"
+		},
+		{
+			"include": "#operators"
+		},
+		{
+			"include": "#numbers"
+		},
+		{
+			"include": "#strings"
+		},
+		{
+			"name": "meta.preprocessor.macro.c",
+			"begin": "((?:(?:(?>\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+?|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))((#)\\s*define\\b)\\s+((?<!\\w)[a-zA-Z_]\\w*(?!\\w))(?:(\\()([^()\\\\]+)(\\)))?",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"2": {
+					"name": "comment.block.c punctuation.definition.comment.begin.c"
+				},
+				"3": {
+					"name": "comment.block.c"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.c punctuation.definition.comment.end.c"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.c"
+						}
+					]
+				},
+				"5": {
+					"name": "keyword.control.directive.define.c"
+				},
+				"6": {
+					"name": "punctuation.definition.directive.c"
+				},
+				"7": {
+					"name": "entity.name.function.preprocessor.c"
+				},
+				"8": {
+					"name": "punctuation.definition.parameters.begin.c"
+				},
+				"9": {
+					"patterns": [
+						{
+							"match": "(?<=[(,])\\s*((?<!\\w)[a-zA-Z_]\\w*(?!\\w))\\s*",
+							"captures": {
+								"1": {
+									"name": "variable.parameter.preprocessor.c"
+								}
+							}
+						},
+						{
+							"match": ",",
+							"name": "punctuation.separator.parameters.c"
+						},
+						{
+							"match": "\\.\\.\\.",
+							"name": "ellipses.c punctuation.vararg-ellipses.variable.parameter.preprocessor.c"
+						}
+					]
+				},
+				"10": {
+					"name": "punctuation.definition.parameters.end.c"
+				}
+			},
+			"end": "(?<!\\\\)(?=\\n)",
+			"patterns": [
+				{
+					"include": "#preprocessor-rule-define-line-contents"
+				}
+			]
+		},
+		{
+			"begin": "^\\s*((#)\\s*(error|warning))\\b\\s*",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.control.directive.diagnostic.$3.c"
+				},
+				"2": {
+					"name": "punctuation.definition.directive.c"
+				}
+			},
+			"end": "(?<!\\\\)(?=\\n)",
+			"name": "meta.preprocessor.diagnostic.c",
+			"patterns": [
+				{
+					"begin": "\"",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.begin.c"
+						}
+					},
+					"end": "\"|(?<!\\\\)(?=\\s*\\n)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.end.c"
+						}
+					},
+					"name": "string.quoted.double.c",
+					"patterns": [
+						{
+							"include": "#line_continuation_character"
+						}
+					]
+				},
+				{
+					"begin": "'",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.begin.c"
+						}
+					},
+					"end": "'|(?<!\\\\)(?=\\s*\\n)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.end.c"
+						}
+					},
+					"name": "string.quoted.single.c",
+					"patterns": [
+						{
+							"include": "#line_continuation_character"
+						}
+					]
+				},
+				{
+					"begin": "[^'\"]",
+					"end": "(?<!\\\\)(?=\\s*\\n)",
+					"name": "string.unquoted.single.c",
+					"patterns": [
+						{
+							"include": "#line_continuation_character"
+						},
+						{
+							"include": "#comments"
+						}
+					]
+				}
+			]
+		},
+		{
+			"begin": "^\\s*((#)\\s*(include(?:_next)?|import))\\b\\s*",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.control.directive.$3.c"
+				},
+				"2": {
+					"name": "punctuation.definition.directive.c"
+				}
+			},
+			"end": "(?=(?://|/\\*))|(?<!\\\\)(?=\\n)",
+			"name": "meta.preprocessor.include.c",
+			"patterns": [
+				{
+					"include": "#line_continuation_character"
+				},
+				{
+					"begin": "\"",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.begin.c"
+						}
+					},
+					"end": "\"",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.end.c"
+						}
+					},
+					"name": "string.quoted.double.include.c"
+				},
+				{
+					"begin": "<",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.begin.c"
+						}
+					},
+					"end": ">",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.end.c"
+						}
+					},
+					"name": "string.quoted.other.lt-gt.include.c"
+				}
+			]
+		},
+		{
+			"include": "#pragma-mark"
+		},
+		{
+			"begin": "^\\s*((#)\\s*line)\\b",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.control.directive.line.c"
+				},
+				"2": {
+					"name": "punctuation.definition.directive.c"
+				}
+			},
+			"end": "(?=(?://|/\\*))|(?<!\\\\)(?=\\n)",
+			"name": "meta.preprocessor.c",
+			"patterns": [
+				{
+					"include": "#strings"
+				},
+				{
+					"include": "#numbers"
+				},
+				{
+					"include": "#line_continuation_character"
+				}
+			]
+		},
+		{
+			"begin": "^\\s*(?:((#)\\s*undef))\\b",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.control.directive.undef.c"
+				},
+				"2": {
+					"name": "punctuation.definition.directive.c"
+				}
+			},
+			"end": "(?=(?://|/\\*))|(?<!\\\\)(?=\\n)",
+			"name": "meta.preprocessor.c",
+			"patterns": [
+				{
+					"match": "[a-zA-Z_$][\\w$]*",
+					"name": "entity.name.function.preprocessor.c"
+				},
+				{
+					"include": "#line_continuation_character"
+				}
+			]
+		},
+		{
+			"begin": "^\\s*(?:((#)\\s*pragma))\\b",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.control.directive.pragma.c"
+				},
+				"2": {
+					"name": "punctuation.definition.directive.c"
+				}
+			},
+			"end": "(?=(?://|/\\*))|(?<!\\\\)(?=\\n)",
+			"name": "meta.preprocessor.pragma.c",
+			"patterns": [
+				{
+					"include": "#strings"
+				},
+				{
+					"match": "[a-zA-Z_$][\\w\\-$]*",
+					"name": "entity.other.attribute-name.pragma.preprocessor.c"
+				},
+				{
+					"include": "#numbers"
+				},
+				{
+					"include": "#line_continuation_character"
+				}
+			]
+		},
+		{
+			"match": "\\b(u_char|u_short|u_int|u_long|ushort|uint|u_quad_t|quad_t|qaddr_t|caddr_t|daddr_t|div_t|dev_t|fixpt_t|blkcnt_t|blksize_t|gid_t|in_addr_t|in_port_t|ino_t|key_t|mode_t|nlink_t|id_t|pid_t|off_t|segsz_t|swblk_t|uid_t|id_t|clock_t|size_t|ssize_t|time_t|useconds_t|suseconds_t)\\b",
+			"name": "support.type.sys-types.c"
+		},
+		{
+			"match": "\\b(pthread_attr_t|pthread_cond_t|pthread_condattr_t|pthread_mutex_t|pthread_mutexattr_t|pthread_once_t|pthread_rwlock_t|pthread_rwlockattr_t|pthread_t|pthread_key_t)\\b",
+			"name": "support.type.pthread.c"
+		},
+		{
+			"match": "(?x) \\b\n(int8_t|int16_t|int32_t|int64_t|uint8_t|uint16_t|uint32_t|uint64_t|int_least8_t\n|int_least16_t|int_least32_t|int_least64_t|uint_least8_t|uint_least16_t|uint_least32_t\n|uint_least64_t|int_fast8_t|int_fast16_t|int_fast32_t|int_fast64_t|uint_fast8_t\n|uint_fast16_t|uint_fast32_t|uint_fast64_t|intptr_t|uintptr_t|intmax_t|intmax_t\n|uintmax_t|uintmax_t)\n\\b",
+			"name": "support.type.stdint.c"
+		},
+		{
+			"match": "\\b(noErr|kNilOptions|kInvalidID|kVariableLengthArray)\\b",
+			"name": "support.constant.mac-classic.c"
+		},
+		{
+			"match": "(?x) \\b\n(AbsoluteTime|Boolean|Byte|ByteCount|ByteOffset|BytePtr|CompTimeValue|ConstLogicalAddress|ConstStrFileNameParam\n|ConstStringPtr|Duration|Fixed|FixedPtr|Float32|Float32Point|Float64|Float80|Float96|FourCharCode|Fract|FractPtr\n|Handle|ItemCount|LogicalAddress|OptionBits|OSErr|OSStatus|OSType|OSTypePtr|PhysicalAddress|ProcessSerialNumber\n|ProcessSerialNumberPtr|ProcHandle|Ptr|ResType|ResTypePtr|ShortFixed|ShortFixedPtr|SignedByte|SInt16|SInt32|SInt64\n|SInt8|Size|StrFileName|StringHandle|StringPtr|TimeBase|TimeRecord|TimeScale|TimeValue|TimeValue64|UInt16|UInt32\n|UInt64|UInt8|UniChar|UniCharCount|UniCharCountPtr|UniCharPtr|UnicodeScalarValue|UniversalProcHandle|UniversalProcPtr\n|UnsignedFixed|UnsignedFixedPtr|UnsignedWide|UTF16Char|UTF32Char|UTF8Char)\n\\b",
+			"name": "support.type.mac-classic.c"
+		},
+		{
+			"match": "\\b([A-Za-z0-9_]+_t)\\b",
+			"name": "support.type.posix-reserved.c"
+		},
+		{
+			"include": "#block"
+		},
+		{
+			"include": "#parens"
+		},
+		{
+			"name": "meta.function.c",
+			"begin": "(?<!\\w)(?!\\s*(?:atomic_uint_least64_t|atomic_uint_least16_t|atomic_uint_least32_t|atomic_uint_least8_t|atomic_int_least16_t|atomic_uint_fast64_t|atomic_uint_fast32_t|atomic_int_least64_t|atomic_int_least32_t|pthread_rwlockattr_t|atomic_uint_fast16_t|pthread_mutexattr_t|atomic_int_fast16_t|atomic_uint_fast8_t|atomic_int_fast64_t|atomic_int_least8_t|atomic_int_fast32_t|atomic_int_fast8_t|pthread_condattr_t|pthread_rwlock_t|atomic_uintptr_t|atomic_ptrdiff_t|atomic_uintmax_t|atomic_intmax_t|atomic_char32_t|atomic_intptr_t|atomic_char16_t|pthread_mutex_t|pthread_cond_t|atomic_wchar_t|uint_least64_t|uint_least32_t|uint_least16_t|pthread_once_t|pthread_attr_t|uint_least8_t|int_least32_t|int_least16_t|pthread_key_t|uint_fast32_t|uint_fast64_t|uint_fast16_t|atomic_size_t|atomic_ushort|atomic_ullong|int_least64_t|atomic_ulong|int_least8_t|int_fast16_t|int_fast32_t|int_fast64_t|uint_fast8_t|memory_order|atomic_schar|atomic_uchar|atomic_short|atomic_llong|thread_local|atomic_bool|atomic_uint|atomic_long|int_fast8_t|suseconds_t|atomic_char|atomic_int|useconds_t|_Imaginary|uintmax_t|uintmax_t|in_addr_t|in_port_t|_Noreturn|blksize_t|pthread_t|uintptr_t|volatile|u_quad_t|blkcnt_t|intmax_t|intptr_t|_Complex|uint16_t|uint32_t|uint64_t|_Alignof|_Alignas|continue|unsigned|restrict|intmax_t|register|int64_t|qaddr_t|segsz_t|_Atomic|alignas|default|caddr_t|nlink_t|typedef|u_short|fixpt_t|clock_t|swblk_t|ssize_t|alignof|daddr_t|int16_t|int32_t|uint8_t|struct|mode_t|size_t|time_t|ushort|u_long|u_char|int8_t|double|signed|static|extern|inline|return|switch|xor_eq|and_eq|bitand|not_eq|sizeof|quad_t|uid_t|bitor|union|off_t|key_t|ino_t|compl|u_int|short|const|false|while|float|pid_t|break|_Bool|or_eq|div_t|dev_t|gid_t|id_t|long|case|goto|else|bool|auto|id_t|enum|uint|true|NULL|void|char|for|not|int|and|xor|do|or|if)\\s*\\()(?=[a-zA-Z_]\\w*\\s*\\()",
+			"end": "(?!\\G)(?<=\\))",
+			"patterns": [
+				{
+					"include": "#function-innards"
+				}
+			]
+		},
+		{
+			"include": "#line_continuation_character"
+		},
+		{
+			"name": "meta.bracket.square.access.c",
+			"begin": "([a-zA-Z_][a-zA-Z_0-9]*|(?<=[\\]\\)]))?(\\[)(?!\\])",
+			"beginCaptures": {
+				"1": {
+					"name": "variable.object.c"
+				},
+				"2": {
+					"name": "punctuation.definition.begin.bracket.square.c"
+				}
+			},
+			"end": "\\]",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.end.bracket.square.c"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#function-call-innards"
+				}
+			]
+		},
+		{
+			"name": "storage.modifier.array.bracket.square.c",
+			"match": "\\[\\s*\\]"
+		},
+		{
+			"match": ";",
+			"name": "punctuation.terminator.statement.c"
+		},
+		{
+			"match": ",",
+			"name": "punctuation.separator.delimiter.c"
+		}
+	],
+	"repository": {
+		"access-method": {
+			"name": "meta.function-call.member.c",
+			"begin": "([a-zA-Z_][a-zA-Z_0-9]*|(?<=[\\]\\)]))\\s*(?:(\\.)|(->))((?:(?:[a-zA-Z_][a-zA-Z_0-9]*)\\s*(?:(?:\\.)|(?:->)))*)\\s*([a-zA-Z_][a-zA-Z_0-9]*)(\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "variable.object.c"
+				},
+				"2": {
+					"name": "punctuation.separator.dot-access.c"
+				},
+				"3": {
+					"name": "punctuation.separator.pointer-access.c"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\.",
+							"name": "punctuation.separator.dot-access.c"
+						},
+						{
+							"match": "->",
+							"name": "punctuation.separator.pointer-access.c"
+						},
+						{
+							"match": "[a-zA-Z_][a-zA-Z_0-9]*",
+							"name": "variable.object.c"
+						},
+						{
+							"name": "everything.else.c",
+							"match": ".+"
+						}
+					]
+				},
+				"5": {
+					"name": "entity.name.function.member.c"
+				},
+				"6": {
+					"name": "punctuation.section.arguments.begin.bracket.round.function.member.c"
+				}
+			},
+			"end": "\\)",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.section.arguments.end.bracket.round.function.member.c"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#function-call-innards"
+				}
+			]
+		},
+		"backslash_escapes": {
+			"match": "(?x)\\\\ (\n\\\\\t\t\t |\n[abefnprtv'\"?]   |\n[0-3][0-7]{,2}\t |\n[4-7]\\d?\t\t|\nx[a-fA-F0-9]{,2} |\nu[a-fA-F0-9]{,4} |\nU[a-fA-F0-9]{,8} )",
+			"name": "constant.character.escape.c"
+		},
+		"block": {
+			"patterns": [
+				{
+					"begin": "{",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.section.block.begin.bracket.curly.c"
+						}
+					},
+					"end": "}|(?=\\s*#\\s*(?:elif|else|endif)\\b)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.section.block.end.bracket.curly.c"
+						}
+					},
+					"name": "meta.block.c",
+					"patterns": [
+						{
+							"include": "#block_innards"
+						}
+					]
+				}
+			]
+		},
+		"block_innards": {
+			"patterns": [
+				{
+					"include": "#preprocessor-rule-enabled-block"
+				},
+				{
+					"include": "#preprocessor-rule-disabled-block"
+				},
+				{
+					"include": "#preprocessor-rule-conditional-block"
+				},
+				{
+					"include": "#method_access"
+				},
+				{
+					"include": "#member_access"
+				},
+				{
+					"include": "#c_function_call"
+				},
+				{
+					"name": "meta.initialization.c",
+					"begin": "(?x)\n(?:\n  (?:\n\t(?=\\s)(?<!else|new|return)\n\t(?<=\\w) \\s+(and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|typeid|xor|xor_eq|alignof|alignas)  # or word + space before name\n  )\n)\n(\n  (?:[A-Za-z_][A-Za-z0-9_]*+ | :: )++   # actual name\n  |\n  (?:(?<=operator) (?:[-*&<>=+!]+ | \\(\\) | \\[\\]))\n)\n\\s*(\\() # opening bracket",
+					"beginCaptures": {
+						"1": {
+							"name": "variable.other.c"
+						},
+						"2": {
+							"name": "punctuation.section.parens.begin.bracket.round.initialization.c"
+						}
+					},
+					"end": "\\)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.section.parens.end.bracket.round.initialization.c"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#function-call-innards"
+						}
+					]
+				},
+				{
+					"begin": "{",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.section.block.begin.bracket.curly.c"
+						}
+					},
+					"end": "}|(?=\\s*#\\s*(?:elif|else|endif)\\b)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.section.block.end.bracket.curly.c"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#block_innards"
+						}
+					]
+				},
+				{
+					"include": "#parens-block"
+				},
+				{
+					"include": "$base"
+				}
+			]
+		},
+		"c_conditional_context": {
+			"patterns": [
+				{
+					"include": "$self"
+				},
+				{
+					"include": "#block_innards"
+				}
+			]
+		},
+		"c_function_call": {
+			"begin": "(?x)\n(?!(?:while|for|do|if|else|switch|catch|enumerate|return|typeid|alignof|alignas|sizeof|[cr]?iterate|and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|typeid|xor|xor_eq|alignof|alignas)\\s*\\()\n(?=\n(?:[A-Za-z_][A-Za-z0-9_]*+|::)++\\s*\\(  # actual name\n|\n(?:(?<=operator)(?:[-*&<>=+!]+|\\(\\)|\\[\\]))\\s*\\(\n)",
+			"end": "(?<=\\))(?!\\w)",
+			"name": "meta.function-call.c",
+			"patterns": [
+				{
+					"include": "#function-call-innards"
+				}
+			]
+		},
+		"case_statement": {
+			"name": "meta.conditional.case.c",
+			"begin": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)case(?!\\w))",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"2": {
+					"name": "comment.block.c punctuation.definition.comment.begin.c"
+				},
+				"3": {
+					"name": "comment.block.c"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.c punctuation.definition.comment.end.c"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.c"
+						}
+					]
+				},
+				"5": {
+					"name": "keyword.control.case.c"
+				}
+			},
+			"end": "(:)",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.separator.colon.case.c"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#evaluation_context"
+				},
+				{
+					"include": "#c_conditional_context"
+				}
+			]
+		},
+		"comments": {
+			"patterns": [
+				{
+					"name": "comment.line.double-slash.documentation.c",
+					"begin": "(?:^)(?>\\s*)(\\/\\/[!\\/]+)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.comment.documentation.c"
+						}
+					},
+					"end": "(?<=\\n)(?<!\\\\\\n)",
+					"patterns": [
+						{
+							"include": "#line_continuation_character"
+						},
+						{
+							"match": "(?<=[\\s*!\\/])[\\\\@](?:callergraph|callgraph|else|endif|f\\$|f\\[|f\\]|hidecallergraph|hidecallgraph|hiderefby|hiderefs|hideinitializer|htmlinclude|n|nosubgrouping|private|privatesection|protected|protectedsection|public|publicsection|pure|showinitializer|showrefby|showrefs|tableofcontents|\\$|\\#|<|>|%|\"|\\.|=|::|\\||\\-\\-|\\-\\-\\-)\\b(?:\\{[^}]*\\})?",
+							"name": "storage.type.class.doxygen.c"
+						},
+						{
+							"match": "((?<=[\\s*!\\/])[\\\\@](?:a|em|e))\\s+(\\S+)",
+							"captures": {
+								"1": {
+									"name": "storage.type.class.doxygen.c"
+								},
+								"2": {
+									"name": "markup.italic.doxygen.c"
+								}
+							}
+						},
+						{
+							"match": "((?<=[\\s*!\\/])[\\\\@]b)\\s+(\\S+)",
+							"captures": {
+								"1": {
+									"name": "storage.type.class.doxygen.c"
+								},
+								"2": {
+									"name": "markup.bold.doxygen.c"
+								}
+							}
+						},
+						{
+							"match": "((?<=[\\s*!\\/])[\\\\@](?:c|p))\\s+(\\S+)",
+							"captures": {
+								"1": {
+									"name": "storage.type.class.doxygen.c"
+								},
+								"2": {
+									"name": "markup.inline.raw.string.c"
+								}
+							}
+						},
+						{
+							"match": "(?<=[\\s*!\\/])[\\\\@](?:a|anchor|b|c|cite|copybrief|copydetail|copydoc|def|dir|dontinclude|e|em|emoji|enum|example|extends|file|idlexcept|implements|include|includedoc|includelineno|latexinclude|link|memberof|namespace|p|package|ref|refitem|related|relates|relatedalso|relatesalso|verbinclude)\\b(?:\\{[^}]*\\})?",
+							"name": "storage.type.class.doxygen.c"
+						},
+						{
+							"match": "(?<=[\\s*!\\/])[\\\\@](?:addindex|addtogroup|category|class|defgroup|diafile|dotfile|elseif|fn|headerfile|if|ifnot|image|ingroup|interface|line|mainpage|mscfile|name|overload|page|property|protocol|section|skip|skipline|snippet|snippetdoc|snippetlineno|struct|subpage|subsection|subsubsection|typedef|union|until|vhdlflow|weakgroup)\\b(?:\\{[^}]*\\})?",
+							"name": "storage.type.class.doxygen.c"
+						},
+						{
+							"match": "((?<=[\\s*!\\/])[\\\\@]param)(?:\\s*\\[((?:,?\\s*(?:in|out)\\s*)+)\\])?\\s+(\\b\\w+\\b)",
+							"captures": {
+								"1": {
+									"name": "storage.type.class.doxygen.c"
+								},
+								"2": {
+									"patterns": [
+										{
+											"match": "in|out",
+											"name": "keyword.other.parameter.direction.$0.c"
+										}
+									]
+								},
+								"3": {
+									"name": "variable.parameter.c"
+								}
+							}
+						},
+						{
+							"match": "(?<=[\\s*!\\/])[\\\\@](?:arg|attention|author|authors|brief|bug|copyright|date|deprecated|details|exception|invariant|li|note|par|paragraph|param|post|pre|remark|remarks|result|return|returns|retval|sa|see|short|since|test|throw|todo|tparam|version|warning|xrefitem)\\b(?:\\{[^}]*\\})?",
+							"name": "storage.type.class.doxygen.c"
+						},
+						{
+							"match": "(?<=[\\s*!\\/])[\\\\@](?:code|cond|docbookonly|dot|htmlonly|internal|latexonly|link|manonly|msc|parblock|rtfonly|secreflist|uml|verbatim|xmlonly|endcode|endcond|enddocbookonly|enddot|endhtmlonly|endinternal|endlatexonly|endlink|endmanonly|endmsc|endparblock|endrtfonly|endsecreflist|enduml|endverbatim|endxmlonly)\\b(?:\\{[^}]*\\})?",
+							"name": "storage.type.class.doxygen.c"
+						},
+						{
+							"match": "(?:\\b[A-Z]+:|@[a-z_]+:)",
+							"name": "storage.type.class.gtkdoc"
+						}
+					]
+				},
+				{
+					"match": "(\\/\\*[!*]+(?=\\s))(.+)([!*]*\\*\\/)",
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.comment.begin.documentation.c"
+						},
+						"2": {
+							"patterns": [
+								{
+									"match": "(?<=[\\s*!\\/])[\\\\@](?:callergraph|callgraph|else|endif|f\\$|f\\[|f\\]|hidecallergraph|hidecallgraph|hiderefby|hiderefs|hideinitializer|htmlinclude|n|nosubgrouping|private|privatesection|protected|protectedsection|public|publicsection|pure|showinitializer|showrefby|showrefs|tableofcontents|\\$|\\#|<|>|%|\"|\\.|=|::|\\||\\-\\-|\\-\\-\\-)\\b(?:\\{[^}]*\\})?",
+									"name": "storage.type.class.doxygen.c"
+								},
+								{
+									"match": "((?<=[\\s*!\\/])[\\\\@](?:a|em|e))\\s+(\\S+)",
+									"captures": {
+										"1": {
+											"name": "storage.type.class.doxygen.c"
+										},
+										"2": {
+											"name": "markup.italic.doxygen.c"
+										}
+									}
+								},
+								{
+									"match": "((?<=[\\s*!\\/])[\\\\@]b)\\s+(\\S+)",
+									"captures": {
+										"1": {
+											"name": "storage.type.class.doxygen.c"
+										},
+										"2": {
+											"name": "markup.bold.doxygen.c"
+										}
+									}
+								},
+								{
+									"match": "((?<=[\\s*!\\/])[\\\\@](?:c|p))\\s+(\\S+)",
+									"captures": {
+										"1": {
+											"name": "storage.type.class.doxygen.c"
+										},
+										"2": {
+											"name": "markup.inline.raw.string.c"
+										}
+									}
+								},
+								{
+									"match": "(?<=[\\s*!\\/])[\\\\@](?:a|anchor|b|c|cite|copybrief|copydetail|copydoc|def|dir|dontinclude|e|em|emoji|enum|example|extends|file|idlexcept|implements|include|includedoc|includelineno|latexinclude|link|memberof|namespace|p|package|ref|refitem|related|relates|relatedalso|relatesalso|verbinclude)\\b(?:\\{[^}]*\\})?",
+									"name": "storage.type.class.doxygen.c"
+								},
+								{
+									"match": "(?<=[\\s*!\\/])[\\\\@](?:addindex|addtogroup|category|class|defgroup|diafile|dotfile|elseif|fn|headerfile|if|ifnot|image|ingroup|interface|line|mainpage|mscfile|name|overload|page|property|protocol|section|skip|skipline|snippet|snippetdoc|snippetlineno|struct|subpage|subsection|subsubsection|typedef|union|until|vhdlflow|weakgroup)\\b(?:\\{[^}]*\\})?",
+									"name": "storage.type.class.doxygen.c"
+								},
+								{
+									"match": "((?<=[\\s*!\\/])[\\\\@]param)(?:\\s*\\[((?:,?\\s*(?:in|out)\\s*)+)\\])?\\s+(\\b\\w+\\b)",
+									"captures": {
+										"1": {
+											"name": "storage.type.class.doxygen.c"
+										},
+										"2": {
+											"patterns": [
+												{
+													"match": "in|out",
+													"name": "keyword.other.parameter.direction.$0.c"
+												}
+											]
+										},
+										"3": {
+											"name": "variable.parameter.c"
+										}
+									}
+								},
+								{
+									"match": "(?<=[\\s*!\\/])[\\\\@](?:arg|attention|author|authors|brief|bug|copyright|date|deprecated|details|exception|invariant|li|note|par|paragraph|param|post|pre|remark|remarks|result|return|returns|retval|sa|see|short|since|test|throw|todo|tparam|version|warning|xrefitem)\\b(?:\\{[^}]*\\})?",
+									"name": "storage.type.class.doxygen.c"
+								},
+								{
+									"match": "(?<=[\\s*!\\/])[\\\\@](?:code|cond|docbookonly|dot|htmlonly|internal|latexonly|link|manonly|msc|parblock|rtfonly|secreflist|uml|verbatim|xmlonly|endcode|endcond|enddocbookonly|enddot|endhtmlonly|endinternal|endlatexonly|endlink|endmanonly|endmsc|endparblock|endrtfonly|endsecreflist|enduml|endverbatim|endxmlonly)\\b(?:\\{[^}]*\\})?",
+									"name": "storage.type.class.doxygen.c"
+								},
+								{
+									"match": "(?:\\b[A-Z]+:|@[a-z_]+:)",
+									"name": "storage.type.class.gtkdoc"
+								}
+							]
+						},
+						"3": {
+							"name": "punctuation.definition.comment.end.documentation.c"
+						}
+					},
+					"name": "comment.block.documentation.c"
+				},
+				{
+					"name": "comment.block.documentation.c",
+					"begin": "((?>\\s*)\\/\\*[!*]+(?:(?:\\n|$)|(?=\\s)))",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.comment.begin.documentation.c"
+						}
+					},
+					"end": "([!*]*\\*\\/)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.comment.end.documentation.c"
+						}
+					},
+					"patterns": [
+						{
+							"match": "(?<=[\\s*!\\/])[\\\\@](?:callergraph|callgraph|else|endif|f\\$|f\\[|f\\]|hidecallergraph|hidecallgraph|hiderefby|hiderefs|hideinitializer|htmlinclude|n|nosubgrouping|private|privatesection|protected|protectedsection|public|publicsection|pure|showinitializer|showrefby|showrefs|tableofcontents|\\$|\\#|<|>|%|\"|\\.|=|::|\\||\\-\\-|\\-\\-\\-)\\b(?:\\{[^}]*\\})?",
+							"name": "storage.type.class.doxygen.c"
+						},
+						{
+							"match": "((?<=[\\s*!\\/])[\\\\@](?:a|em|e))\\s+(\\S+)",
+							"captures": {
+								"1": {
+									"name": "storage.type.class.doxygen.c"
+								},
+								"2": {
+									"name": "markup.italic.doxygen.c"
+								}
+							}
+						},
+						{
+							"match": "((?<=[\\s*!\\/])[\\\\@]b)\\s+(\\S+)",
+							"captures": {
+								"1": {
+									"name": "storage.type.class.doxygen.c"
+								},
+								"2": {
+									"name": "markup.bold.doxygen.c"
+								}
+							}
+						},
+						{
+							"match": "((?<=[\\s*!\\/])[\\\\@](?:c|p))\\s+(\\S+)",
+							"captures": {
+								"1": {
+									"name": "storage.type.class.doxygen.c"
+								},
+								"2": {
+									"name": "markup.inline.raw.string.c"
+								}
+							}
+						},
+						{
+							"match": "(?<=[\\s*!\\/])[\\\\@](?:a|anchor|b|c|cite|copybrief|copydetail|copydoc|def|dir|dontinclude|e|em|emoji|enum|example|extends|file|idlexcept|implements|include|includedoc|includelineno|latexinclude|link|memberof|namespace|p|package|ref|refitem|related|relates|relatedalso|relatesalso|verbinclude)\\b(?:\\{[^}]*\\})?",
+							"name": "storage.type.class.doxygen.c"
+						},
+						{
+							"match": "(?<=[\\s*!\\/])[\\\\@](?:addindex|addtogroup|category|class|defgroup|diafile|dotfile|elseif|fn|headerfile|if|ifnot|image|ingroup|interface|line|mainpage|mscfile|name|overload|page|property|protocol|section|skip|skipline|snippet|snippetdoc|snippetlineno|struct|subpage|subsection|subsubsection|typedef|union|until|vhdlflow|weakgroup)\\b(?:\\{[^}]*\\})?",
+							"name": "storage.type.class.doxygen.c"
+						},
+						{
+							"match": "((?<=[\\s*!\\/])[\\\\@]param)(?:\\s*\\[((?:,?\\s*(?:in|out)\\s*)+)\\])?\\s+(\\b\\w+\\b)",
+							"captures": {
+								"1": {
+									"name": "storage.type.class.doxygen.c"
+								},
+								"2": {
+									"patterns": [
+										{
+											"match": "in|out",
+											"name": "keyword.other.parameter.direction.$0.c"
+										}
+									]
+								},
+								"3": {
+									"name": "variable.parameter.c"
+								}
+							}
+						},
+						{
+							"match": "(?<=[\\s*!\\/])[\\\\@](?:arg|attention|author|authors|brief|bug|copyright|date|deprecated|details|exception|invariant|li|note|par|paragraph|param|post|pre|remark|remarks|result|return|returns|retval|sa|see|short|since|test|throw|todo|tparam|version|warning|xrefitem)\\b(?:\\{[^}]*\\})?",
+							"name": "storage.type.class.doxygen.c"
+						},
+						{
+							"match": "(?<=[\\s*!\\/])[\\\\@](?:code|cond|docbookonly|dot|htmlonly|internal|latexonly|link|manonly|msc|parblock|rtfonly|secreflist|uml|verbatim|xmlonly|endcode|endcond|enddocbookonly|enddot|endhtmlonly|endinternal|endlatexonly|endlink|endmanonly|endmsc|endparblock|endrtfonly|endsecreflist|enduml|endverbatim|endxmlonly)\\b(?:\\{[^}]*\\})?",
+							"name": "storage.type.class.doxygen.c"
+						},
+						{
+							"match": "(?:\\b[A-Z]+:|@[a-z_]+:)",
+							"name": "storage.type.class.gtkdoc"
+						}
+					]
+				},
+				{
+					"match": "^\\/\\* =(\\s*.*?)\\s*= \\*\\/$\\n?",
+					"captures": {
+						"1": {
+							"name": "meta.toc-list.banner.block.c"
+						}
+					},
+					"name": "comment.block.banner.c"
+				},
+				{
+					"name": "comment.block.c",
+					"begin": "(\\/\\*)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.comment.begin.c"
+						}
+					},
+					"end": "(\\*\\/)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.comment.end.c"
+						}
+					}
+				},
+				{
+					"match": "^\\/\\/ =(\\s*.*?)\\s*=$\\n?",
+					"captures": {
+						"1": {
+							"name": "meta.toc-list.banner.line.c"
+						}
+					},
+					"name": "comment.line.banner.c"
+				},
+				{
+					"begin": "((?:^[ \\t]+)?)(?=\\/\\/)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.whitespace.comment.leading.c"
+						}
+					},
+					"end": "(?!\\G)",
+					"patterns": [
+						{
+							"name": "comment.line.double-slash.c",
+							"begin": "(\\/\\/)",
+							"beginCaptures": {
+								"1": {
+									"name": "punctuation.definition.comment.c"
+								}
+							},
+							"end": "(?=\\n)",
+							"patterns": [
+								{
+									"include": "#line_continuation_character"
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		"default_statement": {
+			"name": "meta.conditional.case.c",
+			"begin": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)default(?!\\w))",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"2": {
+					"name": "comment.block.c punctuation.definition.comment.begin.c"
+				},
+				"3": {
+					"name": "comment.block.c"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.c punctuation.definition.comment.end.c"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.c"
+						}
+					]
+				},
+				"5": {
+					"name": "keyword.control.default.c"
+				}
+			},
+			"end": "(:)",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.separator.colon.case.default.c"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#evaluation_context"
+				},
+				{
+					"include": "#c_conditional_context"
+				}
+			]
+		},
+		"disabled": {
+			"begin": "^\\s*#\\s*if(n?def)?\\b.*$",
+			"end": "^\\s*#\\s*endif\\b",
+			"patterns": [
+				{
+					"include": "#disabled"
+				},
+				{
+					"include": "#pragma-mark"
+				}
+			]
+		},
+		"evaluation_context": {
+			"patterns": [
+				{
+					"include": "#function-call-innards"
+				},
+				{
+					"include": "$base"
+				}
+			]
+		},
+		"function-call-innards": {
+			"patterns": [
+				{
+					"include": "#comments"
+				},
+				{
+					"include": "#storage_types"
+				},
+				{
+					"include": "#method_access"
+				},
+				{
+					"include": "#member_access"
+				},
+				{
+					"include": "#operators"
+				},
+				{
+					"begin": "(?x)\n(?!(?:while|for|do|if|else|switch|catch|enumerate|return|typeid|alignof|alignas|sizeof|[cr]?iterate|and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|typeid|xor|xor_eq|alignof|alignas)\\s*\\()\n(\n(?:[A-Za-z_][A-Za-z0-9_]*+|::)++  # actual name\n|\n(?:(?<=operator)(?:[-*&<>=+!]+|\\(\\)|\\[\\]))\n)\n\\s*(\\()",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.function.c"
+						},
+						"2": {
+							"name": "punctuation.section.arguments.begin.bracket.round.c"
+						}
+					},
+					"end": "\\)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.section.arguments.end.bracket.round.c"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#function-call-innards"
+						}
+					]
+				},
+				{
+					"begin": "\\(",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.section.parens.begin.bracket.round.c"
+						}
+					},
+					"end": "\\)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.section.parens.end.bracket.round.c"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#function-call-innards"
+						}
+					]
+				},
+				{
+					"include": "#block_innards"
+				}
+			]
+		},
+		"function-innards": {
+			"patterns": [
+				{
+					"include": "#comments"
+				},
+				{
+					"include": "#storage_types"
+				},
+				{
+					"include": "#operators"
+				},
+				{
+					"include": "#vararg_ellipses"
+				},
+				{
+					"name": "meta.function.definition.parameters.c",
+					"begin": "(?x)\n(?!(?:while|for|do|if|else|switch|catch|enumerate|return|typeid|alignof|alignas|sizeof|[cr]?iterate|and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|typeid|xor|xor_eq|alignof|alignas)\\s*\\()\n(\n(?:[A-Za-z_][A-Za-z0-9_]*+|::)++  # actual name\n|\n(?:(?<=operator)(?:[-*&<>=+!]+|\\(\\)|\\[\\]))\n)\n\\s*(\\()",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.function.c"
+						},
+						"2": {
+							"name": "punctuation.section.parameters.begin.bracket.round.c"
+						}
+					},
+					"end": "\\)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.section.parameters.end.bracket.round.c"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#probably_a_parameter"
+						},
+						{
+							"include": "#function-innards"
+						}
+					]
+				},
+				{
+					"begin": "\\(",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.section.parens.begin.bracket.round.c"
+						}
+					},
+					"end": "\\)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.section.parens.end.bracket.round.c"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#function-innards"
+						}
+					]
+				},
+				{
+					"include": "$base"
+				}
+			]
+		},
+		"inline_comment": {
+			"match": "(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/))",
+			"captures": {
+				"1": {
+					"name": "comment.block.c punctuation.definition.comment.begin.c"
+				},
+				"2": {
+					"name": "comment.block.c"
+				},
+				"3": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.c punctuation.definition.comment.end.c"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.c"
+						}
+					]
+				}
+			}
+		},
+		"line_continuation_character": {
+			"patterns": [
+				{
+					"match": "(\\\\)\\n",
+					"captures": {
+						"1": {
+							"name": "constant.character.escape.line-continuation.c"
+						}
+					}
+				}
+			]
+		},
+		"member_access": {
+			"match": "((?:[a-zA-Z_]\\w*|(?<=\\]|\\)))\\s*)(?:((?:\\.\\*|\\.))|((?:->\\*|->)))((?:[a-zA-Z_]\\w*\\s*(?:(?:(?:\\.\\*|\\.))|(?:(?:->\\*|->)))\\s*)*)\\s*(\\b(?!(?:atomic_uint_least64_t|atomic_uint_least16_t|atomic_uint_least32_t|atomic_uint_least8_t|atomic_int_least16_t|atomic_uint_fast64_t|atomic_uint_fast32_t|atomic_int_least64_t|atomic_int_least32_t|pthread_rwlockattr_t|atomic_uint_fast16_t|pthread_mutexattr_t|atomic_int_fast16_t|atomic_uint_fast8_t|atomic_int_fast64_t|atomic_int_least8_t|atomic_int_fast32_t|atomic_int_fast8_t|pthread_condattr_t|atomic_uintptr_t|atomic_ptrdiff_t|pthread_rwlock_t|atomic_uintmax_t|pthread_mutex_t|atomic_intmax_t|atomic_intptr_t|atomic_char32_t|atomic_char16_t|pthread_attr_t|atomic_wchar_t|uint_least64_t|uint_least32_t|uint_least16_t|pthread_cond_t|pthread_once_t|uint_fast64_t|uint_fast16_t|atomic_size_t|uint_least8_t|int_least64_t|int_least32_t|int_least16_t|pthread_key_t|atomic_ullong|atomic_ushort|uint_fast32_t|atomic_schar|atomic_short|uint_fast8_t|int_fast64_t|int_fast32_t|int_fast16_t|atomic_ulong|atomic_llong|int_least8_t|atomic_uchar|memory_order|suseconds_t|int_fast8_t|atomic_bool|atomic_char|atomic_uint|atomic_long|atomic_int|useconds_t|_Imaginary|blksize_t|pthread_t|in_addr_t|uintptr_t|in_port_t|uintmax_t|uintmax_t|blkcnt_t|uint16_t|unsigned|_Complex|uint32_t|intptr_t|intmax_t|intmax_t|uint64_t|u_quad_t|int64_t|int32_t|ssize_t|caddr_t|clock_t|uint8_t|u_short|swblk_t|segsz_t|int16_t|fixpt_t|daddr_t|nlink_t|qaddr_t|size_t|time_t|mode_t|signed|quad_t|ushort|u_long|u_char|double|int8_t|ino_t|uid_t|pid_t|_Bool|float|dev_t|div_t|short|gid_t|off_t|u_int|key_t|id_t|uint|long|void|char|bool|id_t|int)\\b)[a-zA-Z_]\\w*\\b(?!\\())",
+			"captures": {
+				"1": {
+					"name": "variable.other.object.access.c"
+				},
+				"2": {
+					"name": "punctuation.separator.dot-access.c"
+				},
+				"3": {
+					"name": "punctuation.separator.pointer-access.c"
+				},
+				"4": {
+					"patterns": [
+						{
+							"include": "#member_access"
+						},
+						{
+							"include": "#method_access"
+						},
+						{
+							"match": "((?:[a-zA-Z_]\\w*|(?<=\\]|\\)))\\s*)(?:((?:\\.\\*|\\.))|((?:->\\*|->)))",
+							"captures": {
+								"1": {
+									"name": "variable.other.object.access.c"
+								},
+								"2": {
+									"name": "punctuation.separator.dot-access.c"
+								},
+								"3": {
+									"name": "punctuation.separator.pointer-access.c"
+								}
+							}
+						}
+					]
+				},
+				"5": {
+					"name": "variable.other.member.c"
+				}
+			}
+		},
+		"method_access": {
+			"contentName": "meta.function-call.member.c",
+			"begin": "((?:[a-zA-Z_]\\w*|(?<=\\]|\\)))\\s*)(?:((?:\\.\\*|\\.))|((?:->\\*|->)))((?:[a-zA-Z_]\\w*\\s*(?:(?:(?:\\.\\*|\\.))|(?:(?:->\\*|->)))\\s*)*)\\s*([a-zA-Z_]\\w*)(\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "variable.other.object.access.c"
+				},
+				"2": {
+					"name": "punctuation.separator.dot-access.c"
+				},
+				"3": {
+					"name": "punctuation.separator.pointer-access.c"
+				},
+				"4": {
+					"patterns": [
+						{
+							"include": "#member_access"
+						},
+						{
+							"include": "#method_access"
+						},
+						{
+							"match": "((?:[a-zA-Z_]\\w*|(?<=\\]|\\)))\\s*)(?:((?:\\.\\*|\\.))|((?:->\\*|->)))",
+							"captures": {
+								"1": {
+									"name": "variable.other.object.access.c"
+								},
+								"2": {
+									"name": "punctuation.separator.dot-access.c"
+								},
+								"3": {
+									"name": "punctuation.separator.pointer-access.c"
+								}
+							}
+						}
+					]
+				},
+				"5": {
+					"name": "entity.name.function.member.c"
+				},
+				"6": {
+					"name": "punctuation.section.arguments.begin.bracket.round.function.member.c"
+				}
+			},
+			"end": "(\\))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.arguments.end.bracket.round.function.member.c"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#function-call-innards"
+				}
+			]
+		},
+		"numbers": {
+			"match": "(?<!\\w)\\.?\\d(?:(?:[0-9a-zA-Z_\\.]|')|(?<=[eEpP])[+-])*",
+			"captures": {
+				"0": {
+					"patterns": [
+						{
+							"begin": "(?=.)",
+							"end": "$",
+							"patterns": [
+								{
+									"match": "(\\G0[xX])([0-9a-fA-F](?:[0-9a-fA-F]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)?((?:(?<=[0-9a-fA-F])\\.|\\.(?=[0-9a-fA-F])))([0-9a-fA-F](?:[0-9a-fA-F]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)?((?<!')([pP])(\\+?)(\\-?)((?:[0-9](?:[0-9]|(?:(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)))?([lLfF](?!\\w))?$",
+									"captures": {
+										"1": {
+											"name": "keyword.other.unit.hexadecimal.c"
+										},
+										"2": {
+											"name": "constant.numeric.hexadecimal.c",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric"
+												}
+											]
+										},
+										"3": {
+											"name": "punctuation.separator.constant.numeric"
+										},
+										"4": {
+											"name": "constant.numeric.hexadecimal.c"
+										},
+										"5": {
+											"name": "constant.numeric.hexadecimal.c",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric"
+												}
+											]
+										},
+										"6": {
+											"name": "punctuation.separator.constant.numeric"
+										},
+										"8": {
+											"name": "keyword.other.unit.exponent.hexadecimal.c"
+										},
+										"9": {
+											"name": "keyword.operator.plus.exponent.hexadecimal.c"
+										},
+										"10": {
+											"name": "keyword.operator.minus.exponent.hexadecimal.c"
+										},
+										"11": {
+											"name": "constant.numeric.exponent.hexadecimal.c",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric"
+												}
+											]
+										},
+										"12": {
+											"name": "keyword.other.unit.suffix.floating-point.c"
+										}
+									}
+								},
+								{
+									"match": "(\\G(?=[0-9.])(?!0[xXbB]))([0-9](?:[0-9]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)?((?:(?<=[0-9])\\.|\\.(?=[0-9])))([0-9](?:[0-9]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)?((?<!')([eE])(\\+?)(\\-?)((?:[0-9](?:[0-9]|(?:(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)))?([lLfF](?!\\w))?$",
+									"captures": {
+										"2": {
+											"name": "constant.numeric.decimal.c",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric"
+												}
+											]
+										},
+										"3": {
+											"name": "punctuation.separator.constant.numeric"
+										},
+										"4": {
+											"name": "constant.numeric.decimal.point.c"
+										},
+										"5": {
+											"name": "constant.numeric.decimal.c",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric"
+												}
+											]
+										},
+										"6": {
+											"name": "punctuation.separator.constant.numeric"
+										},
+										"8": {
+											"name": "keyword.other.unit.exponent.decimal.c"
+										},
+										"9": {
+											"name": "keyword.operator.plus.exponent.decimal.c"
+										},
+										"10": {
+											"name": "keyword.operator.minus.exponent.decimal.c"
+										},
+										"11": {
+											"name": "constant.numeric.exponent.decimal.c",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric"
+												}
+											]
+										},
+										"12": {
+											"name": "keyword.other.unit.suffix.floating-point.c"
+										}
+									}
+								},
+								{
+									"match": "(\\G0[bB])([01](?:[01]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)((?:(?:(?:(?:(?:[uU]|[uU]ll?)|[uU]LL?)|ll?[uU]?)|LL?[uU]?)|[fF])(?!\\w))?$",
+									"captures": {
+										"1": {
+											"name": "keyword.other.unit.binary.c"
+										},
+										"2": {
+											"name": "constant.numeric.binary.c",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric"
+												}
+											]
+										},
+										"3": {
+											"name": "punctuation.separator.constant.numeric"
+										},
+										"4": {
+											"name": "keyword.other.unit.suffix.integer.c"
+										}
+									}
+								},
+								{
+									"match": "(\\G0)((?:[0-7]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))+)((?:(?:(?:(?:(?:[uU]|[uU]ll?)|[uU]LL?)|ll?[uU]?)|LL?[uU]?)|[fF])(?!\\w))?$",
+									"captures": {
+										"1": {
+											"name": "keyword.other.unit.octal.c"
+										},
+										"2": {
+											"name": "constant.numeric.octal.c",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric"
+												}
+											]
+										},
+										"3": {
+											"name": "punctuation.separator.constant.numeric"
+										},
+										"4": {
+											"name": "keyword.other.unit.suffix.integer.c"
+										}
+									}
+								},
+								{
+									"match": "(\\G0[xX])([0-9a-fA-F](?:[0-9a-fA-F]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)((?<!')([pP])(\\+?)(\\-?)((?:[0-9](?:[0-9]|(?:(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)))?((?:(?:(?:(?:(?:[uU]|[uU]ll?)|[uU]LL?)|ll?[uU]?)|LL?[uU]?)|[fF])(?!\\w))?$",
+									"captures": {
+										"1": {
+											"name": "keyword.other.unit.hexadecimal.c"
+										},
+										"2": {
+											"name": "constant.numeric.hexadecimal.c",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric"
+												}
+											]
+										},
+										"3": {
+											"name": "punctuation.separator.constant.numeric"
+										},
+										"5": {
+											"name": "keyword.other.unit.exponent.hexadecimal.c"
+										},
+										"6": {
+											"name": "keyword.operator.plus.exponent.hexadecimal.c"
+										},
+										"7": {
+											"name": "keyword.operator.minus.exponent.hexadecimal.c"
+										},
+										"8": {
+											"name": "constant.numeric.exponent.hexadecimal.c",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric"
+												}
+											]
+										},
+										"9": {
+											"name": "keyword.other.unit.suffix.integer.c"
+										}
+									}
+								},
+								{
+									"match": "(\\G(?=[0-9.])(?!0[xXbB]))([0-9](?:[0-9]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)((?<!')([eE])(\\+?)(\\-?)((?:[0-9](?:[0-9]|(?:(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)))?((?:(?:(?:(?:(?:[uU]|[uU]ll?)|[uU]LL?)|ll?[uU]?)|LL?[uU]?)|[fF])(?!\\w))?$",
+									"captures": {
+										"2": {
+											"name": "constant.numeric.decimal.c",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric"
+												}
+											]
+										},
+										"3": {
+											"name": "punctuation.separator.constant.numeric"
+										},
+										"5": {
+											"name": "keyword.other.unit.exponent.decimal.c"
+										},
+										"6": {
+											"name": "keyword.operator.plus.exponent.decimal.c"
+										},
+										"7": {
+											"name": "keyword.operator.minus.exponent.decimal.c"
+										},
+										"8": {
+											"name": "constant.numeric.exponent.decimal.c",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric"
+												}
+											]
+										},
+										"9": {
+											"name": "keyword.other.unit.suffix.integer.c"
+										}
+									}
+								},
+								{
+									"match": "(?:(?:[0-9a-zA-Z_\\.]|')|(?<=[eEpP])[+-])+",
+									"name": "invalid.illegal.constant.numeric"
+								}
+							]
+						}
+					]
+				}
+			}
+		},
+		"operators": {
+			"patterns": [
+				{
+					"match": "(?<![\\w$])(sizeof)(?![\\w$])",
+					"name": "keyword.operator.sizeof.c"
+				},
+				{
+					"match": "--",
+					"name": "keyword.operator.decrement.c"
+				},
+				{
+					"match": "\\+\\+",
+					"name": "keyword.operator.increment.c"
+				},
+				{
+					"match": "%=|\\+=|-=|\\*=|(?<!\\()/=",
+					"name": "keyword.operator.assignment.compound.c"
+				},
+				{
+					"match": "&=|\\^=|<<=|>>=|\\|=",
+					"name": "keyword.operator.assignment.compound.bitwise.c"
+				},
+				{
+					"match": "<<|>>",
+					"name": "keyword.operator.bitwise.shift.c"
+				},
+				{
+					"match": "!=|<=|>=|==|<|>",
+					"name": "keyword.operator.comparison.c"
+				},
+				{
+					"match": "&&|!|\\|\\|",
+					"name": "keyword.operator.logical.c"
+				},
+				{
+					"match": "&|\\||\\^|~",
+					"name": "keyword.operator.c"
+				},
+				{
+					"match": "=",
+					"name": "keyword.operator.assignment.c"
+				},
+				{
+					"match": "%|\\*|/|-|\\+",
+					"name": "keyword.operator.c"
+				},
+				{
+					"begin": "(\\?)",
+					"beginCaptures": {
+						"1": {
+							"name": "keyword.operator.ternary.c"
+						}
+					},
+					"end": "(:)",
+					"endCaptures": {
+						"1": {
+							"name": "keyword.operator.ternary.c"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#function-call-innards"
+						},
+						{
+							"include": "$base"
+						}
+					]
+				}
+			]
+		},
+		"parens": {
+			"name": "meta.parens.c",
+			"begin": "\\(",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.section.parens.begin.bracket.round.c"
+				}
+			},
+			"end": "\\)",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.section.parens.end.bracket.round.c"
+				}
+			},
+			"patterns": [
+				{
+					"include": "$base"
+				}
+			]
+		},
+		"parens-block": {
+			"name": "meta.parens.block.c",
+			"begin": "\\(",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.section.parens.begin.bracket.round.c"
+				}
+			},
+			"end": "\\)",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.section.parens.end.bracket.round.c"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#block_innards"
+				},
+				{
+					"match": "(?-mix:(?<!:):(?!:))",
+					"name": "punctuation.range-based.c"
+				}
+			]
+		},
+		"pragma-mark": {
+			"captures": {
+				"1": {
+					"name": "meta.preprocessor.pragma.c"
+				},
+				"2": {
+					"name": "keyword.control.directive.pragma.pragma-mark.c"
+				},
+				"3": {
+					"name": "punctuation.definition.directive.c"
+				},
+				"4": {
+					"name": "entity.name.tag.pragma-mark.c"
+				}
+			},
+			"match": "^\\s*(((#)\\s*pragma\\s+mark)\\s+(.*))",
+			"name": "meta.section.c"
+		},
+		"predefined_macros": {
+			"patterns": [
+				{
+					"match": "\\b(__cplusplus|__DATE__|__FILE__|__LINE__|__STDC__|__STDC_HOSTED__|__STDC_NO_COMPLEX__|__STDC_VERSION__|__STDCPP_THREADS__|__TIME__|NDEBUG|__OBJC__|__ASSEMBLER__|__ATOM__|__AVX__|__AVX2__|_CHAR_UNSIGNED|__CLR_VER|_CONTROL_FLOW_GUARD|__COUNTER__|__cplusplus_cli|__cplusplus_winrt|_CPPRTTI|_CPPUNWIND|_DEBUG|_DLL|__FUNCDNAME__|__FUNCSIG__|__FUNCTION__|_INTEGRAL_MAX_BITS|__INTELLISENSE__|_ISO_VOLATILE|_KERNEL_MODE|_M_AMD64|_M_ARM|_M_ARM_ARMV7VE|_M_ARM_FP|_M_ARM64|_M_CEE|_M_CEE_PURE|_M_CEE_SAFE|_M_FP_EXCEPT|_M_FP_FAST|_M_FP_PRECISE|_M_FP_STRICT|_M_IX86|_M_IX86_FP|_M_X64|_MANAGED|_MSC_BUILD|_MSC_EXTENSIONS|_MSC_FULL_VER|_MSC_VER|_MSVC_LANG|__MSVC_RUNTIME_CHECKS|_MT|_NATIVE_WCHAR_T_DEFINED|_OPENMP|_PREFAST|__TIMESTAMP__|_VC_NO_DEFAULTLIB|_WCHAR_T_DEFINED|_WIN32|_WIN64|_WINRT_DLL|_ATL_VER|_MFC_VER|__GFORTRAN__|__GNUC__|__GNUC_MINOR__|__GNUC_PATCHLEVEL__|__GNUG__|__STRICT_ANSI__|__BASE_FILE__|__INCLUDE_LEVEL__|__ELF__|__VERSION__|__OPTIMIZE__|__OPTIMIZE_SIZE__|__NO_INLINE__|__GNUC_STDC_INLINE__|__CHAR_UNSIGNED__|__WCHAR_UNSIGNED__|__REGISTER_PREFIX__|__REGISTER_PREFIX__|__SIZE_TYPE__|__PTRDIFF_TYPE__|__WCHAR_TYPE__|__WINT_TYPE__|__INTMAX_TYPE__|__UINTMAX_TYPE__|__SIG_ATOMIC_TYPE__|__INT8_TYPE__|__INT16_TYPE__|__INT32_TYPE__|__INT64_TYPE__|__UINT8_TYPE__|__UINT16_TYPE__|__UINT32_TYPE__|__UINT64_TYPE__|__INT_LEAST8_TYPE__|__INT_LEAST16_TYPE__|__INT_LEAST32_TYPE__|__INT_LEAST64_TYPE__|__UINT_LEAST8_TYPE__|__UINT_LEAST16_TYPE__|__UINT_LEAST32_TYPE__|__UINT_LEAST64_TYPE__|__INT_FAST8_TYPE__|__INT_FAST16_TYPE__|__INT_FAST32_TYPE__|__INT_FAST64_TYPE__|__UINT_FAST8_TYPE__|__UINT_FAST16_TYPE__|__UINT_FAST32_TYPE__|__UINT_FAST64_TYPE__|__INTPTR_TYPE__|__UINTPTR_TYPE__|__CHAR_BIT__|__SCHAR_MAX__|__WCHAR_MAX__|__SHRT_MAX__|__INT_MAX__|__LONG_MAX__|__LONG_LONG_MAX__|__WINT_MAX__|__SIZE_MAX__|__PTRDIFF_MAX__|__INTMAX_MAX__|__UINTMAX_MAX__|__SIG_ATOMIC_MAX__|__INT8_MAX__|__INT16_MAX__|__INT32_MAX__|__INT64_MAX__|__UINT8_MAX__|__UINT16_MAX__|__UINT32_MAX__|__UINT64_MAX__|__INT_LEAST8_MAX__|__INT_LEAST16_MAX__|__INT_LEAST32_MAX__|__INT_LEAST64_MAX__|__UINT_LEAST8_MAX__|__UINT_LEAST16_MAX__|__UINT_LEAST32_MAX__|__UINT_LEAST64_MAX__|__INT_FAST8_MAX__|__INT_FAST16_MAX__|__INT_FAST32_MAX__|__INT_FAST64_MAX__|__UINT_FAST8_MAX__|__UINT_FAST16_MAX__|__UINT_FAST32_MAX__|__UINT_FAST64_MAX__|__INTPTR_MAX__|__UINTPTR_MAX__|__WCHAR_MIN__|__WINT_MIN__|__SIG_ATOMIC_MIN__|__SCHAR_WIDTH__|__SHRT_WIDTH__|__INT_WIDTH__|__LONG_WIDTH__|__LONG_LONG_WIDTH__|__PTRDIFF_WIDTH__|__SIG_ATOMIC_WIDTH__|__SIZE_WIDTH__|__WCHAR_WIDTH__|__WINT_WIDTH__|__INT_LEAST8_WIDTH__|__INT_LEAST16_WIDTH__|__INT_LEAST32_WIDTH__|__INT_LEAST64_WIDTH__|__INT_FAST8_WIDTH__|__INT_FAST16_WIDTH__|__INT_FAST32_WIDTH__|__INT_FAST64_WIDTH__|__INTPTR_WIDTH__|__INTMAX_WIDTH__|__SIZEOF_INT__|__SIZEOF_LONG__|__SIZEOF_LONG_LONG__|__SIZEOF_SHORT__|__SIZEOF_POINTER__|__SIZEOF_FLOAT__|__SIZEOF_DOUBLE__|__SIZEOF_LONG_DOUBLE__|__SIZEOF_SIZE_T__|__SIZEOF_WCHAR_T__|__SIZEOF_WINT_T__|__SIZEOF_PTRDIFF_T__|__BYTE_ORDER__|__ORDER_LITTLE_ENDIAN__|__ORDER_BIG_ENDIAN__|__ORDER_PDP_ENDIAN__|__FLOAT_WORD_ORDER__|__DEPRECATED|__EXCEPTIONS|__GXX_RTTI|__USING_SJLJ_EXCEPTIONS__|__GXX_EXPERIMENTAL_CXX0X__|__GXX_WEAK__|__NEXT_RUNTIME__|__LP64__|_LP64|__SSP__|__SSP_ALL__|__SSP_STRONG__|__SSP_EXPLICIT__|__SANITIZE_ADDRESS__|__SANITIZE_THREAD__|__GCC_HAVE_SYNC_COMPARE_AND_SWAP_1|__GCC_HAVE_SYNC_COMPARE_AND_SWAP_2|__GCC_HAVE_SYNC_COMPARE_AND_SWAP_4|__GCC_HAVE_SYNC_COMPARE_AND_SWAP_8|__GCC_HAVE_SYNC_COMPARE_AND_SWAP_16|__HAVE_SPECULATION_SAFE_VALUE|__GCC_HAVE_DWARF2_CFI_ASM|__FP_FAST_FMA|__FP_FAST_FMAF|__FP_FAST_FMAL|__FP_FAST_FMAF16|__FP_FAST_FMAF32|__FP_FAST_FMAF64|__FP_FAST_FMAF128|__FP_FAST_FMAF32X|__FP_FAST_FMAF64X|__FP_FAST_FMAF128X|__GCC_IEC_559|__GCC_IEC_559_COMPLEX|__NO_MATH_ERRNO__|__has_builtin|__has_feature|__has_extension|__has_cpp_attribute|__has_c_attribute|__has_attribute|__has_declspec_attribute|__is_identifier|__has_include|__has_include_next|__has_warning|__BASE_FILE__|__FILE_NAME__|__clang__|__clang_major__|__clang_minor__|__clang_patchlevel__|__clang_version__|__fp16|_Float16)\\b",
+					"captures": {
+						"1": {
+							"name": "entity.name.other.preprocessor.macro.predefined.$1.c"
+						}
+					}
+				},
+				{
+					"match": "\\b__([A-Z_]+)__\\b",
+					"name": "entity.name.other.preprocessor.macro.predefined.probably.$1.c"
+				}
+			]
+		},
+		"preprocessor-rule-conditional": {
+			"patterns": [
+				{
+					"begin": "^\\s*((#)\\s*if(?:n?def)?\\b)",
+					"beginCaptures": {
+						"0": {
+							"name": "meta.preprocessor.c"
+						},
+						"1": {
+							"name": "keyword.control.directive.conditional.c"
+						},
+						"2": {
+							"name": "punctuation.definition.directive.c"
+						}
+					},
+					"end": "^\\s*((#)\\s*endif\\b)",
+					"endCaptures": {
+						"0": {
+							"name": "meta.preprocessor.c"
+						},
+						"1": {
+							"name": "keyword.control.directive.conditional.c"
+						},
+						"2": {
+							"name": "punctuation.definition.directive.c"
+						}
+					},
+					"patterns": [
+						{
+							"begin": "\\G(?=.)(?!//|/\\*(?!.*\\\\\\s*\\n))",
+							"end": "(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?<!\\\\)(?=\\n)",
+							"name": "meta.preprocessor.c",
+							"patterns": [
+								{
+									"include": "#preprocessor-rule-conditional-line"
+								}
+							]
+						},
+						{
+							"include": "#preprocessor-rule-enabled-elif"
+						},
+						{
+							"include": "#preprocessor-rule-enabled-else"
+						},
+						{
+							"include": "#preprocessor-rule-disabled-elif"
+						},
+						{
+							"begin": "^\\s*((#)\\s*elif\\b)",
+							"beginCaptures": {
+								"1": {
+									"name": "keyword.control.directive.conditional.c"
+								},
+								"2": {
+									"name": "punctuation.definition.directive.c"
+								}
+							},
+							"end": "(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?<!\\\\)(?=\\n)",
+							"name": "meta.preprocessor.c",
+							"patterns": [
+								{
+									"include": "#preprocessor-rule-conditional-line"
+								}
+							]
+						},
+						{
+							"include": "$base"
+						}
+					]
+				},
+				{
+					"match": "^\\s*#\\s*(else|elif|endif)\\b",
+					"captures": {
+						"0": {
+							"name": "invalid.illegal.stray-$1.c"
+						}
+					}
+				}
+			]
+		},
+		"preprocessor-rule-conditional-block": {
+			"patterns": [
+				{
+					"begin": "^\\s*((#)\\s*if(?:n?def)?\\b)",
+					"beginCaptures": {
+						"0": {
+							"name": "meta.preprocessor.c"
+						},
+						"1": {
+							"name": "keyword.control.directive.conditional.c"
+						},
+						"2": {
+							"name": "punctuation.definition.directive.c"
+						}
+					},
+					"end": "^\\s*((#)\\s*endif\\b)",
+					"endCaptures": {
+						"0": {
+							"name": "meta.preprocessor.c"
+						},
+						"1": {
+							"name": "keyword.control.directive.conditional.c"
+						},
+						"2": {
+							"name": "punctuation.definition.directive.c"
+						}
+					},
+					"patterns": [
+						{
+							"begin": "\\G(?=.)(?!//|/\\*(?!.*\\\\\\s*\\n))",
+							"end": "(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?<!\\\\)(?=\\n)",
+							"name": "meta.preprocessor.c",
+							"patterns": [
+								{
+									"include": "#preprocessor-rule-conditional-line"
+								}
+							]
+						},
+						{
+							"include": "#preprocessor-rule-enabled-elif-block"
+						},
+						{
+							"include": "#preprocessor-rule-enabled-else-block"
+						},
+						{
+							"include": "#preprocessor-rule-disabled-elif"
+						},
+						{
+							"begin": "^\\s*((#)\\s*elif\\b)",
+							"beginCaptures": {
+								"1": {
+									"name": "keyword.control.directive.conditional.c"
+								},
+								"2": {
+									"name": "punctuation.definition.directive.c"
+								}
+							},
+							"end": "(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?<!\\\\)(?=\\n)",
+							"name": "meta.preprocessor.c",
+							"patterns": [
+								{
+									"include": "#preprocessor-rule-conditional-line"
+								}
+							]
+						},
+						{
+							"include": "#block_innards"
+						}
+					]
+				},
+				{
+					"match": "^\\s*#\\s*(else|elif|endif)\\b",
+					"captures": {
+						"0": {
+							"name": "invalid.illegal.stray-$1.c"
+						}
+					}
+				}
+			]
+		},
+		"preprocessor-rule-conditional-line": {
+			"patterns": [
+				{
+					"match": "(?:\\bdefined\\b\\s*$)|(?:\\bdefined\\b(?=\\s*\\(*\\s*(?:(?!defined\\b)[a-zA-Z_$][\\w$]*\\b)\\s*\\)*\\s*(?:\\n|//|/\\*|\\?|\\:|&&|\\|\\||\\\\\\s*\\n)))",
+					"name": "keyword.control.directive.conditional.c"
+				},
+				{
+					"match": "\\bdefined\\b",
+					"name": "invalid.illegal.macro-name.c"
+				},
+				{
+					"include": "#comments"
+				},
+				{
+					"include": "#strings"
+				},
+				{
+					"include": "#numbers"
+				},
+				{
+					"begin": "\\?",
+					"beginCaptures": {
+						"0": {
+							"name": "keyword.operator.ternary.c"
+						}
+					},
+					"end": ":",
+					"endCaptures": {
+						"0": {
+							"name": "keyword.operator.ternary.c"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#preprocessor-rule-conditional-line"
+						}
+					]
+				},
+				{
+					"include": "#operators"
+				},
+				{
+					"match": "\\b(NULL|true|false|TRUE|FALSE)\\b",
+					"name": "constant.language.c"
+				},
+				{
+					"match": "[a-zA-Z_$][\\w$]*",
+					"name": "entity.name.function.preprocessor.c"
+				},
+				{
+					"include": "#line_continuation_character"
+				},
+				{
+					"begin": "\\(",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.section.parens.begin.bracket.round.c"
+						}
+					},
+					"end": "\\)|(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?<!\\\\)(?=\\n)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.section.parens.end.bracket.round.c"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#preprocessor-rule-conditional-line"
+						}
+					]
+				}
+			]
+		},
+		"preprocessor-rule-define-line-blocks": {
+			"patterns": [
+				{
+					"begin": "{",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.section.block.begin.bracket.curly.c"
+						}
+					},
+					"end": "}|(?=\\s*#\\s*(?:elif|else|endif)\\b)|(?<!\\\\)(?=\\s*\\n)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.section.block.end.bracket.curly.c"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#preprocessor-rule-define-line-blocks"
+						},
+						{
+							"include": "#preprocessor-rule-define-line-contents"
+						}
+					]
+				},
+				{
+					"include": "#preprocessor-rule-define-line-contents"
+				}
+			]
+		},
+		"preprocessor-rule-define-line-contents": {
+			"patterns": [
+				{
+					"include": "#vararg_ellipses"
+				},
+				{
+					"begin": "{",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.section.block.begin.bracket.curly.c"
+						}
+					},
+					"end": "}|(?=\\s*#\\s*(?:elif|else|endif)\\b)|(?<!\\\\)(?=\\s*\\n)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.section.block.end.bracket.curly.c"
+						}
+					},
+					"name": "meta.block.c",
+					"patterns": [
+						{
+							"include": "#preprocessor-rule-define-line-blocks"
+						}
+					]
+				},
+				{
+					"match": "\\(",
+					"name": "punctuation.section.parens.begin.bracket.round.c"
+				},
+				{
+					"match": "\\)",
+					"name": "punctuation.section.parens.end.bracket.round.c"
+				},
+				{
+					"begin": "(?x)\n(?!(?:while|for|do|if|else|switch|catch|enumerate|return|typeid|alignof|alignas|sizeof|[cr]?iterate|and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|typeid|xor|xor_eq|alignof|alignas|asm|__asm__|auto|bool|_Bool|char|_Complex|double|enum|float|_Imaginary|int|long|short|signed|struct|typedef|union|unsigned|void)\\s*\\()\n(?=\n  (?:[A-Za-z_][A-Za-z0-9_]*+|::)++\\s*\\(  # actual name\n  |\n  (?:(?<=operator)(?:[-*&<>=+!]+|\\(\\)|\\[\\]))\\s*\\(\n)",
+					"end": "(?<=\\))(?!\\w)|(?<!\\\\)(?=\\s*\\n)",
+					"name": "meta.function.c",
+					"patterns": [
+						{
+							"include": "#preprocessor-rule-define-line-functions"
+						}
+					]
+				},
+				{
+					"begin": "\"",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.begin.c"
+						}
+					},
+					"end": "\"|(?<!\\\\)(?=\\s*\\n)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.end.c"
+						}
+					},
+					"name": "string.quoted.double.c",
+					"patterns": [
+						{
+							"include": "#string_escaped_char"
+						},
+						{
+							"include": "#string_placeholder"
+						},
+						{
+							"include": "#line_continuation_character"
+						}
+					]
+				},
+				{
+					"begin": "'",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.begin.c"
+						}
+					},
+					"end": "'|(?<!\\\\)(?=\\s*\\n)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.end.c"
+						}
+					},
+					"name": "string.quoted.single.c",
+					"patterns": [
+						{
+							"include": "#string_escaped_char"
+						},
+						{
+							"include": "#line_continuation_character"
+						}
+					]
+				},
+				{
+					"include": "#method_access"
+				},
+				{
+					"include": "#member_access"
+				},
+				{
+					"include": "$base"
+				}
+			]
+		},
+		"preprocessor-rule-define-line-functions": {
+			"patterns": [
+				{
+					"include": "#comments"
+				},
+				{
+					"include": "#storage_types"
+				},
+				{
+					"include": "#vararg_ellipses"
+				},
+				{
+					"include": "#method_access"
+				},
+				{
+					"include": "#member_access"
+				},
+				{
+					"include": "#operators"
+				},
+				{
+					"begin": "(?x)\n(?!(?:while|for|do|if|else|switch|catch|enumerate|return|typeid|alignof|alignas|sizeof|[cr]?iterate|and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|typeid|xor|xor_eq|alignof|alignas)\\s*\\()\n(\n(?:[A-Za-z_][A-Za-z0-9_]*+|::)++  # actual name\n|\n(?:(?<=operator)(?:[-*&<>=+!]+|\\(\\)|\\[\\]))\n)\n\\s*(\\()",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.function.c"
+						},
+						"2": {
+							"name": "punctuation.section.arguments.begin.bracket.round.c"
+						}
+					},
+					"end": "(\\))|(?<!\\\\)(?=\\s*\\n)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.section.arguments.end.bracket.round.c"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#preprocessor-rule-define-line-functions"
+						}
+					]
+				},
+				{
+					"begin": "\\(",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.section.parens.begin.bracket.round.c"
+						}
+					},
+					"end": "(\\))|(?<!\\\\)(?=\\s*\\n)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.section.parens.end.bracket.round.c"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#preprocessor-rule-define-line-functions"
+						}
+					]
+				},
+				{
+					"include": "#preprocessor-rule-define-line-contents"
+				}
+			]
+		},
+		"preprocessor-rule-disabled": {
+			"patterns": [
+				{
+					"begin": "^\\s*((#)\\s*if\\b)(?=\\s*\\(*\\b0+\\b\\)*\\s*(?:$|//|/\\*))",
+					"beginCaptures": {
+						"0": {
+							"name": "meta.preprocessor.c"
+						},
+						"1": {
+							"name": "keyword.control.directive.conditional.c"
+						},
+						"2": {
+							"name": "punctuation.definition.directive.c"
+						}
+					},
+					"end": "^\\s*((#)\\s*endif\\b)",
+					"endCaptures": {
+						"0": {
+							"name": "meta.preprocessor.c"
+						},
+						"1": {
+							"name": "keyword.control.directive.conditional.c"
+						},
+						"2": {
+							"name": "punctuation.definition.directive.c"
+						}
+					},
+					"patterns": [
+						{
+							"begin": "\\G(?=.)(?!//|/\\*(?!.*\\\\\\s*\\n))",
+							"end": "(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?=\\n)",
+							"name": "meta.preprocessor.c",
+							"patterns": [
+								{
+									"include": "#preprocessor-rule-conditional-line"
+								}
+							]
+						},
+						{
+							"include": "#comments"
+						},
+						{
+							"include": "#preprocessor-rule-enabled-elif"
+						},
+						{
+							"include": "#preprocessor-rule-enabled-else"
+						},
+						{
+							"include": "#preprocessor-rule-disabled-elif"
+						},
+						{
+							"begin": "^\\s*((#)\\s*elif\\b)",
+							"beginCaptures": {
+								"0": {
+									"name": "meta.preprocessor.c"
+								},
+								"1": {
+									"name": "keyword.control.directive.conditional.c"
+								},
+								"2": {
+									"name": "punctuation.definition.directive.c"
+								}
+							},
+							"end": "(?=^\\s*((#)\\s*(?:elif|else|endif)\\b))",
+							"patterns": [
+								{
+									"begin": "\\G(?=.)(?!//|/\\*(?!.*\\\\\\s*\\n))",
+									"end": "(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?<!\\\\)(?=\\n)",
+									"name": "meta.preprocessor.c",
+									"patterns": [
+										{
+											"include": "#preprocessor-rule-conditional-line"
+										}
+									]
+								},
+								{
+									"include": "$base"
+								}
+							]
+						},
+						{
+							"begin": "\\n",
+							"end": "(?=^\\s*((#)\\s*(?:else|elif|endif)\\b))",
+							"contentName": "comment.block.preprocessor.if-branch.c",
+							"patterns": [
+								{
+									"include": "#disabled"
+								},
+								{
+									"include": "#pragma-mark"
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		"preprocessor-rule-disabled-block": {
+			"patterns": [
+				{
+					"begin": "^\\s*((#)\\s*if\\b)(?=\\s*\\(*\\b0+\\b\\)*\\s*(?:$|//|/\\*))",
+					"beginCaptures": {
+						"0": {
+							"name": "meta.preprocessor.c"
+						},
+						"1": {
+							"name": "keyword.control.directive.conditional.c"
+						},
+						"2": {
+							"name": "punctuation.definition.directive.c"
+						}
+					},
+					"end": "^\\s*((#)\\s*endif\\b)",
+					"endCaptures": {
+						"0": {
+							"name": "meta.preprocessor.c"
+						},
+						"1": {
+							"name": "keyword.control.directive.conditional.c"
+						},
+						"2": {
+							"name": "punctuation.definition.directive.c"
+						}
+					},
+					"patterns": [
+						{
+							"begin": "\\G(?=.)(?!//|/\\*(?!.*\\\\\\s*\\n))",
+							"end": "(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?=\\n)",
+							"name": "meta.preprocessor.c",
+							"patterns": [
+								{
+									"include": "#preprocessor-rule-conditional-line"
+								}
+							]
+						},
+						{
+							"include": "#comments"
+						},
+						{
+							"include": "#preprocessor-rule-enabled-elif-block"
+						},
+						{
+							"include": "#preprocessor-rule-enabled-else-block"
+						},
+						{
+							"include": "#preprocessor-rule-disabled-elif"
+						},
+						{
+							"begin": "^\\s*((#)\\s*elif\\b)",
+							"beginCaptures": {
+								"0": {
+									"name": "meta.preprocessor.c"
+								},
+								"1": {
+									"name": "keyword.control.directive.conditional.c"
+								},
+								"2": {
+									"name": "punctuation.definition.directive.c"
+								}
+							},
+							"end": "(?=^\\s*((#)\\s*(?:elif|else|endif)\\b))",
+							"patterns": [
+								{
+									"begin": "\\G(?=.)(?!//|/\\*(?!.*\\\\\\s*\\n))",
+									"end": "(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?<!\\\\)(?=\\n)",
+									"name": "meta.preprocessor.c",
+									"patterns": [
+										{
+											"include": "#preprocessor-rule-conditional-line"
+										}
+									]
+								},
+								{
+									"include": "#block_innards"
+								}
+							]
+						},
+						{
+							"begin": "\\n",
+							"end": "(?=^\\s*((#)\\s*(?:else|elif|endif)\\b))",
+							"contentName": "comment.block.preprocessor.if-branch.in-block.c",
+							"patterns": [
+								{
+									"include": "#disabled"
+								},
+								{
+									"include": "#pragma-mark"
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		"preprocessor-rule-disabled-elif": {
+			"begin": "^\\s*((#)\\s*elif\\b)(?=\\s*\\(*\\b0+\\b\\)*\\s*(?:$|//|/\\*))",
+			"beginCaptures": {
+				"0": {
+					"name": "meta.preprocessor.c"
+				},
+				"1": {
+					"name": "keyword.control.directive.conditional.c"
+				},
+				"2": {
+					"name": "punctuation.definition.directive.c"
+				}
+			},
+			"end": "(?=^\\s*((#)\\s*(?:elif|else|endif)\\b))",
+			"patterns": [
+				{
+					"begin": "\\G(?=.)(?!//|/\\*(?!.*\\\\\\s*\\n))",
+					"end": "(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?<!\\\\)(?=\\n)",
+					"name": "meta.preprocessor.c",
+					"patterns": [
+						{
+							"include": "#preprocessor-rule-conditional-line"
+						}
+					]
+				},
+				{
+					"include": "#comments"
+				},
+				{
+					"begin": "\\n",
+					"end": "(?=^\\s*((#)\\s*(?:else|elif|endif)\\b))",
+					"contentName": "comment.block.preprocessor.elif-branch.c",
+					"patterns": [
+						{
+							"include": "#disabled"
+						},
+						{
+							"include": "#pragma-mark"
+						}
+					]
+				}
+			]
+		},
+		"preprocessor-rule-enabled": {
+			"patterns": [
+				{
+					"begin": "^\\s*((#)\\s*if\\b)(?=\\s*\\(*\\b0*1\\b\\)*\\s*(?:$|//|/\\*))",
+					"beginCaptures": {
+						"0": {
+							"name": "meta.preprocessor.c"
+						},
+						"1": {
+							"name": "keyword.control.directive.conditional.c"
+						},
+						"2": {
+							"name": "punctuation.definition.directive.c"
+						},
+						"3": {
+							"name": "constant.numeric.preprocessor.c"
+						}
+					},
+					"end": "^\\s*((#)\\s*endif\\b)",
+					"endCaptures": {
+						"0": {
+							"name": "meta.preprocessor.c"
+						},
+						"1": {
+							"name": "keyword.control.directive.conditional.c"
+						},
+						"2": {
+							"name": "punctuation.definition.directive.c"
+						}
+					},
+					"patterns": [
+						{
+							"begin": "\\G(?=.)(?!//|/\\*(?!.*\\\\\\s*\\n))",
+							"end": "(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?=\\n)",
+							"name": "meta.preprocessor.c",
+							"patterns": [
+								{
+									"include": "#preprocessor-rule-conditional-line"
+								}
+							]
+						},
+						{
+							"include": "#comments"
+						},
+						{
+							"begin": "^\\s*((#)\\s*else\\b)",
+							"beginCaptures": {
+								"0": {
+									"name": "meta.preprocessor.c"
+								},
+								"1": {
+									"name": "keyword.control.directive.conditional.c"
+								},
+								"2": {
+									"name": "punctuation.definition.directive.c"
+								}
+							},
+							"end": "(?=^\\s*((#)\\s*endif\\b))",
+							"contentName": "comment.block.preprocessor.else-branch.c",
+							"patterns": [
+								{
+									"include": "#disabled"
+								},
+								{
+									"include": "#pragma-mark"
+								}
+							]
+						},
+						{
+							"begin": "^\\s*((#)\\s*elif\\b)",
+							"beginCaptures": {
+								"0": {
+									"name": "meta.preprocessor.c"
+								},
+								"1": {
+									"name": "keyword.control.directive.conditional.c"
+								},
+								"2": {
+									"name": "punctuation.definition.directive.c"
+								}
+							},
+							"end": "(?=^\\s*((#)\\s*(?:else|elif|endif)\\b))",
+							"contentName": "comment.block.preprocessor.if-branch.c",
+							"patterns": [
+								{
+									"include": "#disabled"
+								},
+								{
+									"include": "#pragma-mark"
+								}
+							]
+						},
+						{
+							"begin": "\\n",
+							"end": "(?=^\\s*((#)\\s*(?:else|elif|endif)\\b))",
+							"patterns": [
+								{
+									"include": "$base"
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		"preprocessor-rule-enabled-block": {
+			"patterns": [
+				{
+					"begin": "^\\s*((#)\\s*if\\b)(?=\\s*\\(*\\b0*1\\b\\)*\\s*(?:$|//|/\\*))",
+					"beginCaptures": {
+						"0": {
+							"name": "meta.preprocessor.c"
+						},
+						"1": {
+							"name": "keyword.control.directive.conditional.c"
+						},
+						"2": {
+							"name": "punctuation.definition.directive.c"
+						}
+					},
+					"end": "^\\s*((#)\\s*endif\\b)",
+					"endCaptures": {
+						"0": {
+							"name": "meta.preprocessor.c"
+						},
+						"1": {
+							"name": "keyword.control.directive.conditional.c"
+						},
+						"2": {
+							"name": "punctuation.definition.directive.c"
+						}
+					},
+					"patterns": [
+						{
+							"begin": "\\G(?=.)(?!//|/\\*(?!.*\\\\\\s*\\n))",
+							"end": "(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?=\\n)",
+							"name": "meta.preprocessor.c",
+							"patterns": [
+								{
+									"include": "#preprocessor-rule-conditional-line"
+								}
+							]
+						},
+						{
+							"include": "#comments"
+						},
+						{
+							"begin": "^\\s*((#)\\s*else\\b)",
+							"beginCaptures": {
+								"0": {
+									"name": "meta.preprocessor.c"
+								},
+								"1": {
+									"name": "keyword.control.directive.conditional.c"
+								},
+								"2": {
+									"name": "punctuation.definition.directive.c"
+								}
+							},
+							"end": "(?=^\\s*((#)\\s*endif\\b))",
+							"contentName": "comment.block.preprocessor.else-branch.in-block.c",
+							"patterns": [
+								{
+									"include": "#disabled"
+								},
+								{
+									"include": "#pragma-mark"
+								}
+							]
+						},
+						{
+							"begin": "^\\s*((#)\\s*elif\\b)",
+							"beginCaptures": {
+								"0": {
+									"name": "meta.preprocessor.c"
+								},
+								"1": {
+									"name": "keyword.control.directive.conditional.c"
+								},
+								"2": {
+									"name": "punctuation.definition.directive.c"
+								}
+							},
+							"end": "(?=^\\s*((#)\\s*(?:else|elif|endif)\\b))",
+							"contentName": "comment.block.preprocessor.if-branch.in-block.c",
+							"patterns": [
+								{
+									"include": "#disabled"
+								},
+								{
+									"include": "#pragma-mark"
+								}
+							]
+						},
+						{
+							"begin": "\\n",
+							"end": "(?=^\\s*((#)\\s*(?:else|elif|endif)\\b))",
+							"patterns": [
+								{
+									"include": "#block_innards"
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		"preprocessor-rule-enabled-elif": {
+			"begin": "^\\s*((#)\\s*elif\\b)(?=\\s*\\(*\\b0*1\\b\\)*\\s*(?:$|//|/\\*))",
+			"beginCaptures": {
+				"0": {
+					"name": "meta.preprocessor.c"
+				},
+				"1": {
+					"name": "keyword.control.directive.conditional.c"
+				},
+				"2": {
+					"name": "punctuation.definition.directive.c"
+				}
+			},
+			"end": "(?=^\\s*((#)\\s*endif\\b))",
+			"patterns": [
+				{
+					"begin": "\\G(?=.)(?!//|/\\*(?!.*\\\\\\s*\\n))",
+					"end": "(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?<!\\\\)(?=\\n)",
+					"name": "meta.preprocessor.c",
+					"patterns": [
+						{
+							"include": "#preprocessor-rule-conditional-line"
+						}
+					]
+				},
+				{
+					"include": "#comments"
+				},
+				{
+					"begin": "\\n",
+					"end": "(?=^\\s*((#)\\s*(?:endif)\\b))",
+					"patterns": [
+						{
+							"begin": "^\\s*((#)\\s*(else)\\b)",
+							"beginCaptures": {
+								"0": {
+									"name": "meta.preprocessor.c"
+								},
+								"1": {
+									"name": "keyword.control.directive.conditional.c"
+								},
+								"2": {
+									"name": "punctuation.definition.directive.c"
+								}
+							},
+							"end": "(?=^\\s*((#)\\s*endif\\b))",
+							"contentName": "comment.block.preprocessor.elif-branch.c",
+							"patterns": [
+								{
+									"include": "#disabled"
+								},
+								{
+									"include": "#pragma-mark"
+								}
+							]
+						},
+						{
+							"begin": "^\\s*((#)\\s*(elif)\\b)",
+							"beginCaptures": {
+								"0": {
+									"name": "meta.preprocessor.c"
+								},
+								"1": {
+									"name": "keyword.control.directive.conditional.c"
+								},
+								"2": {
+									"name": "punctuation.definition.directive.c"
+								}
+							},
+							"end": "(?=^\\s*((#)\\s*(?:else|elif|endif)\\b))",
+							"contentName": "comment.block.preprocessor.elif-branch.c",
+							"patterns": [
+								{
+									"include": "#disabled"
+								},
+								{
+									"include": "#pragma-mark"
+								}
+							]
+						},
+						{
+							"include": "$base"
+						}
+					]
+				}
+			]
+		},
+		"preprocessor-rule-enabled-elif-block": {
+			"begin": "^\\s*((#)\\s*elif\\b)(?=\\s*\\(*\\b0*1\\b\\)*\\s*(?:$|//|/\\*))",
+			"beginCaptures": {
+				"0": {
+					"name": "meta.preprocessor.c"
+				},
+				"1": {
+					"name": "keyword.control.directive.conditional.c"
+				},
+				"2": {
+					"name": "punctuation.definition.directive.c"
+				}
+			},
+			"end": "(?=^\\s*((#)\\s*endif\\b))",
+			"patterns": [
+				{
+					"begin": "\\G(?=.)(?!//|/\\*(?!.*\\\\\\s*\\n))",
+					"end": "(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?<!\\\\)(?=\\n)",
+					"name": "meta.preprocessor.c",
+					"patterns": [
+						{
+							"include": "#preprocessor-rule-conditional-line"
+						}
+					]
+				},
+				{
+					"include": "#comments"
+				},
+				{
+					"begin": "\\n",
+					"end": "(?=^\\s*((#)\\s*(?:endif)\\b))",
+					"patterns": [
+						{
+							"begin": "^\\s*((#)\\s*(else)\\b)",
+							"beginCaptures": {
+								"0": {
+									"name": "meta.preprocessor.c"
+								},
+								"1": {
+									"name": "keyword.control.directive.conditional.c"
+								},
+								"2": {
+									"name": "punctuation.definition.directive.c"
+								}
+							},
+							"end": "(?=^\\s*((#)\\s*endif\\b))",
+							"contentName": "comment.block.preprocessor.elif-branch.in-block.c",
+							"patterns": [
+								{
+									"include": "#disabled"
+								},
+								{
+									"include": "#pragma-mark"
+								}
+							]
+						},
+						{
+							"begin": "^\\s*((#)\\s*(elif)\\b)",
+							"beginCaptures": {
+								"0": {
+									"name": "meta.preprocessor.c"
+								},
+								"1": {
+									"name": "keyword.control.directive.conditional.c"
+								},
+								"2": {
+									"name": "punctuation.definition.directive.c"
+								}
+							},
+							"end": "(?=^\\s*((#)\\s*(?:else|elif|endif)\\b))",
+							"contentName": "comment.block.preprocessor.elif-branch.c",
+							"patterns": [
+								{
+									"include": "#disabled"
+								},
+								{
+									"include": "#pragma-mark"
+								}
+							]
+						},
+						{
+							"include": "#block_innards"
+						}
+					]
+				}
+			]
+		},
+		"preprocessor-rule-enabled-else": {
+			"begin": "^\\s*((#)\\s*else\\b)",
+			"beginCaptures": {
+				"0": {
+					"name": "meta.preprocessor.c"
+				},
+				"1": {
+					"name": "keyword.control.directive.conditional.c"
+				},
+				"2": {
+					"name": "punctuation.definition.directive.c"
+				}
+			},
+			"end": "(?=^\\s*((#)\\s*endif\\b))",
+			"patterns": [
+				{
+					"include": "$base"
+				}
+			]
+		},
+		"preprocessor-rule-enabled-else-block": {
+			"begin": "^\\s*((#)\\s*else\\b)",
+			"beginCaptures": {
+				"0": {
+					"name": "meta.preprocessor.c"
+				},
+				"1": {
+					"name": "keyword.control.directive.conditional.c"
+				},
+				"2": {
+					"name": "punctuation.definition.directive.c"
+				}
+			},
+			"end": "(?=^\\s*((#)\\s*endif\\b))",
+			"patterns": [
+				{
+					"include": "#block_innards"
+				}
+			]
+		},
+		"probably_a_parameter": {
+			"match": "(?<=(?:[a-zA-Z_0-9] |[&*>\\]\\)]))\\s*([a-zA-Z_]\\w*)\\s*(?=(?:\\[\\]\\s*)?(?:,|\\)))",
+			"captures": {
+				"1": {
+					"name": "variable.parameter.probably.c"
+				}
+			}
+		},
+		"static_assert": {
+			"begin": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)static_assert|_Static_assert(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(\\()",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"2": {
+					"name": "comment.block.c punctuation.definition.comment.begin.c"
+				},
+				"3": {
+					"name": "comment.block.c"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.c punctuation.definition.comment.end.c"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.c"
+						}
+					]
+				},
+				"5": {
+					"name": "keyword.other.static_assert.c"
+				},
+				"6": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"7": {
+					"name": "comment.block.c punctuation.definition.comment.begin.c"
+				},
+				"8": {
+					"name": "comment.block.c"
+				},
+				"9": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.c punctuation.definition.comment.end.c"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.c"
+						}
+					]
+				},
+				"10": {
+					"name": "punctuation.section.arguments.begin.bracket.round.static_assert.c"
+				}
+			},
+			"end": "(\\))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.arguments.end.bracket.round.static_assert.c"
+				}
+			},
+			"patterns": [
+				{
+					"name": "meta.static_assert.message.c",
+					"begin": "(,)\\s*(?=(?:L|u8|u|U\\s*\\\")?)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.separator.delimiter.comma.c"
+						}
+					},
+					"end": "(?=\\))",
+					"patterns": [
+						{
+							"include": "#string_context"
+						}
+					]
+				},
+				{
+					"include": "#evaluation_context"
+				}
+			]
+		},
+		"storage_types": {
+			"patterns": [
+				{
+					"match": "(?-mix:(?<!\\w)(?:unsigned|signed|double|_Bool|short|float|long|void|char|bool|int)(?!\\w))",
+					"name": "storage.type.built-in.primitive.c"
+				},
+				{
+					"match": "(?-mix:(?<!\\w)(?:atomic_uint_least64_t|atomic_uint_least16_t|atomic_uint_least32_t|pthread_rwlockattr_t|atomic_uint_fast64_t|atomic_uint_fast32_t|atomic_uint_fast16_t|atomic_int_least64_t|atomic_int_least32_t|atomic_int_least16_t|atomic_uint_least8_t|atomic_uint_fast8_t|atomic_int_least8_t|atomic_int_fast16_t|pthread_mutexattr_t|atomic_int_fast32_t|atomic_int_fast64_t|atomic_int_fast8_t|pthread_condattr_t|atomic_ptrdiff_t|pthread_rwlock_t|atomic_uintptr_t|atomic_uintmax_t|atomic_intmax_t|atomic_intptr_t|atomic_char32_t|atomic_char16_t|pthread_mutex_t|pthread_cond_t|atomic_wchar_t|uint_least64_t|uint_least32_t|uint_least16_t|pthread_once_t|pthread_attr_t|int_least32_t|pthread_key_t|int_least16_t|int_least64_t|uint_least8_t|uint_fast16_t|uint_fast32_t|uint_fast64_t|atomic_ushort|atomic_ullong|atomic_size_t|int_fast16_t|int_fast64_t|uint_fast8_t|atomic_short|atomic_uchar|atomic_schar|int_least8_t|memory_order|atomic_llong|atomic_ulong|int_fast32_t|atomic_long|atomic_uint|atomic_char|int_fast8_t|suseconds_t|atomic_bool|atomic_int|_Imaginary|useconds_t|in_port_t|uintmax_t|uintmax_t|pthread_t|blksize_t|in_addr_t|uintptr_t|blkcnt_t|uint16_t|uint32_t|uint64_t|u_quad_t|_Complex|intptr_t|intmax_t|intmax_t|segsz_t|u_short|nlink_t|uint8_t|int64_t|int32_t|int16_t|fixpt_t|daddr_t|caddr_t|qaddr_t|ssize_t|clock_t|swblk_t|u_long|mode_t|int8_t|time_t|ushort|u_char|quad_t|size_t|pid_t|gid_t|uid_t|dev_t|div_t|off_t|u_int|key_t|ino_t|uint|id_t|id_t)(?!\\w))",
+					"name": "storage.type.built-in.c"
+				},
+				{
+					"match": "(?-mix:\\b(enum|struct|union)\\b)",
+					"name": "storage.type.$1.c"
+				}
+			]
+		},
+		"string_escaped_char": {
+			"patterns": [
+				{
+					"match": "(?x)\\\\ (\n\\\\\t\t\t |\n[abefnprtv'\"?]   |\n[0-3]\\d{,2}\t |\n[4-7]\\d?\t\t|\nx[a-fA-F0-9]{,2} |\nu[a-fA-F0-9]{,4} |\nU[a-fA-F0-9]{,8} )",
+					"name": "constant.character.escape.c"
+				},
+				{
+					"match": "\\\\.",
+					"name": "invalid.illegal.unknown-escape.c"
+				}
+			]
+		},
+		"string_placeholder": {
+			"patterns": [
+				{
+					"match": "(?x) %\n(\\d+\\$)?\t\t\t\t\t\t   # field (argument #)\n[#0\\- +']*\t\t\t\t\t\t  # flags\n[,;:_]?\t\t\t\t\t\t\t  # separator character (AltiVec)\n((-?\\d+)|\\*(-?\\d+\\$)?)?\t\t  # minimum field width\n(\\.((-?\\d+)|\\*(-?\\d+\\$)?)?)?\t# precision\n(hh|h|ll|l|j|t|z|q|L|vh|vl|v|hv|hl)? # length modifier\n[diouxXDOUeEfFgGaACcSspn%]\t\t   # conversion type",
+					"name": "constant.other.placeholder.c"
+				},
+				{
+					"match": "(%)(?!\"\\s*(PRI|SCN))",
+					"captures": {
+						"1": {
+							"name": "invalid.illegal.placeholder.c"
+						}
+					}
+				}
+			]
+		},
+		"strings": {
+			"patterns": [
+				{
+					"begin": "\"",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.begin.c"
+						}
+					},
+					"end": "\"",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.end.c"
+						}
+					},
+					"name": "string.quoted.double.c",
+					"patterns": [
+						{
+							"include": "#string_escaped_char"
+						},
+						{
+							"include": "#string_placeholder"
+						},
+						{
+							"include": "#line_continuation_character"
+						}
+					]
+				},
+				{
+					"begin": "'",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.begin.c"
+						}
+					},
+					"end": "'",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.end.c"
+						}
+					},
+					"name": "string.quoted.single.c",
+					"patterns": [
+						{
+							"include": "#string_escaped_char"
+						},
+						{
+							"include": "#line_continuation_character"
+						}
+					]
+				}
+			]
+		},
+		"switch_conditional_parentheses": {
+			"name": "meta.conditional.switch.c",
+			"begin": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(\\()",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"2": {
+					"name": "comment.block.c punctuation.definition.comment.begin.c"
+				},
+				"3": {
+					"name": "comment.block.c"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.c punctuation.definition.comment.end.c"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.c"
+						}
+					]
+				},
+				"5": {
+					"name": "punctuation.section.parens.begin.bracket.round.conditional.switch.c"
+				}
+			},
+			"end": "(\\))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.parens.end.bracket.round.conditional.switch.c"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#evaluation_context"
+				},
+				{
+					"include": "#c_conditional_context"
+				}
+			]
+		},
+		"switch_statement": {
+			"name": "meta.block.switch.c",
+			"begin": "(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)switch(?!\\w)))",
+			"beginCaptures": {
+				"1": {
+					"name": "meta.head.switch.c"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.c punctuation.definition.comment.begin.c"
+				},
+				"4": {
+					"name": "comment.block.c"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.c punctuation.definition.comment.end.c"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.c"
+						}
+					]
+				},
+				"6": {
+					"name": "keyword.control.switch.c"
+				}
+			},
+			"end": "(?:(?<=\\}|%>|\\?\\?>)|(?=[;>\\[\\]=]))",
+			"patterns": [
+				{
+					"name": "meta.head.switch.c",
+					"begin": "\\G ?",
+					"end": "((?:\\{|<%|\\?\\?<|(?=;)))",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.section.block.begin.bracket.curly.switch.c"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#switch_conditional_parentheses"
+						},
+						{
+							"include": "$self"
+						}
+					]
+				},
+				{
+					"name": "meta.body.switch.c",
+					"begin": "(?<=\\{|<%|\\?\\?<)",
+					"end": "(\\}|%>|\\?\\?>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.section.block.end.bracket.curly.switch.c"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#default_statement"
+						},
+						{
+							"include": "#case_statement"
+						},
+						{
+							"include": "$self"
+						},
+						{
+							"include": "#block_innards"
+						}
+					]
+				},
+				{
+					"name": "meta.tail.switch.c",
+					"begin": "(?<=\\}|%>|\\?\\?>)[\\s\\n]*",
+					"end": "[\\s\\n]*(?=;)",
+					"patterns": [
+						{
+							"include": "$self"
+						}
+					]
+				}
+			]
+		},
+		"vararg_ellipses": {
+			"match": "(?<!\\.)\\.\\.\\.(?!\\.)",
+			"name": "punctuation.vararg-ellipses.c"
+		}
+	}
+}

--- a/org.eclipse.tm4e.feature/feature.xml
+++ b/org.eclipse.tm4e.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.tm4e.feature"
       label="%featureName"
-      version="0.5.1.qualifier"
+      version="0.5.2.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.tm4e.feature/pom.xml
+++ b/org.eclipse.tm4e.feature/pom.xml
@@ -10,5 +10,5 @@
 
 	<artifactId>org.eclipse.tm4e.feature</artifactId>
 	<packaging>eclipse-feature</packaging>
-	<version>0.5.1-SNAPSHOT</version>
+	<version>0.5.2-SNAPSHOT</version>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,11 @@
 				</executions>
 				<dependencies>
 					<dependency>
+						<groupId>org.apache.maven.surefire</groupId>
+						<artifactId>surefire-junit-platform</artifactId>
+						<version>3.0.0-M7</version>
+					</dependency>
+					<dependency>
 						<groupId>org.junit.jupiter</groupId>
 						<artifactId>junit-jupiter-engine</artifactId>
 						<version>5.9.1</version>


### PR DESCRIPTION
When you type something like the following code in C/C++:

```
struct S {
    //! мышка (just a mouse, only 1)
    char mouse; // syntax colouring of this string will be broken
    //! кошка (just a cat, only 1)
    char cat; // syntax colouring of this string will be broken
};
```

the syntax colouring of a line below the triggering string will be broken. I've managed to reproduce this behaviour with the latest build of Eclipse Corrosion and the most current TM4E snapshot, you can see it in the animated gif below.

![cat_and_mouse](https://user-images.githubusercontent.com/56013880/194773889-b128d644-56f9-4d0b-9939-12118b2d95b1.gif)

EDIT: Double-checked this today with the provided example: in my case (Eclipse CDT with a small patch to connect the extension point of the generic editor to the TMPresentationReconciler of TM4E) without this fix I also had the following exception:
```
java.lang.IllegalArgumentException: Argument not valid
	at org.eclipse.swt.SWT.error(SWT.java:4899)
	at org.eclipse.swt.SWT.error(SWT.java:4833)
	at org.eclipse.swt.SWT.error(SWT.java:4804)
	at org.eclipse.swt.custom.StyledText.setStyleRanges(StyledText.java:10665)
	at org.eclipse.swt.custom.StyledText.replaceStyleRanges(StyledText.java:8238)
	at org.eclipse.jface.text.TextViewer.addPresentation(TextViewer.java:4777)
	at org.eclipse.jface.text.TextViewer.changeTextPresentation(TextViewer.java:4854)
	at org.eclipse.tm4e.ui.text.TMPresentationReconciler.applyTextRegionCollection(TMPresentationReconciler.java:692)
	at org.eclipse.tm4e.ui.text.TMPresentationReconciler.colorize(TMPresentationReconciler.java:596)
	at org.eclipse.tm4e.ui.text.TMPresentationReconciler$InternalListener.colorize(TMPresentationReconciler.java:410)
```
And so debugging this one had lead me to the LineTokenizer trying to handle the captured token of negative length.
