### PR TITLE
fix scopeName of Regular Expressions (JavaScript)

### DIFF
--- a/org.eclipse.tm4e.language_pack.feature/feature.xml
+++ b/org.eclipse.tm4e.language_pack.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.tm4e.language_pack.feature"
       label="%featureName"
-      version="0.1.0.qualifier"
+      version="0.1.1.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.tm4e.language_pack.feature/pom.xml
+++ b/org.eclipse.tm4e.language_pack.feature/pom.xml
@@ -10,5 +10,5 @@
 
 	<artifactId>org.eclipse.tm4e.language_pack.feature</artifactId>
 	<packaging>eclipse-feature</packaging>
-	<version>0.1.0-SNAPSHOT</version>
+	<version>0.1.1-SNAPSHOT</version>
 </project>

--- a/org.eclipse.tm4e.language_pack/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.language_pack/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tm4e.language_pack;singleton:=true
-Bundle-Version: 0.1.0.qualifier
+Bundle-Version: 0.1.1.qualifier
 Require-Bundle: org.eclipse.tm4e.ui;bundle-version="[0.1.0,2.0.0)",
  org.eclipse.tm4e.registry;bundle-version="[0.1.0,2.0.0)",
  org.eclipse.tm4e.languageconfiguration;bundle-version="[0.1.0,2.0.0)",

--- a/org.eclipse.tm4e.language_pack/javascript/Regular Expressions (JavaScript).tmLanguage
+++ b/org.eclipse.tm4e.language_pack/javascript/Regular Expressions (JavaScript).tmLanguage
@@ -230,7 +230,7 @@
 		</dict>
 	</dict>
 	<key>scopeName</key>
-	<string>source.js.regexp</string>
+	<string>lngpck.source.js.regexp</string>
 	<key>uuid</key>
 	<string>AC8679DE-3AC7-4056-84F9-69A7ADC29DDD</string>
 </dict>

--- a/org.eclipse.tm4e.language_pack/pom.xml
+++ b/org.eclipse.tm4e.language_pack/pom.xml
@@ -10,5 +10,5 @@
 
 	<artifactId>org.eclipse.tm4e.language_pack</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.1.0-SNAPSHOT</version>
+	<version>0.1.1-SNAPSHOT</version>
 </project>


### PR DESCRIPTION
This fix is the tiniest one. When trying to open any *.txt file in generic editor with the org.eclipse.tm4e.language_pack installed one can get the following error:
![fail_screen](https://user-images.githubusercontent.com/56013880/194820392-6c2099a9-3984-4719-8c71-3a370687f988.png)