### PR TITLE
Contribute "Source" menu entry in ui plugin instead of langcfg plugin

### DIFF
--- a/org.eclipse.tm4e.languageconfiguration/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.languageconfiguration/META-INF/MANIFEST.MF
@@ -4,13 +4,13 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tm4e.languageconfiguration;singleton:=true
-Bundle-Version: 0.5.3.qualifier
+Bundle-Version: 0.5.4.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.jface.text,
  org.eclipse.ui.genericeditor,
  com.google.gson;bundle-version="2.9.0",
  org.eclipse.tm4e.core;bundle-version="0.5.1",
- org.eclipse.tm4e.ui;bundle-version="0.6.1",
+ org.eclipse.tm4e.ui;bundle-version="0.6.2",
  org.eclipse.core.runtime,
  org.eclipse.core.resources,
  org.eclipse.ui,

--- a/org.eclipse.tm4e.languageconfiguration/plugin.properties
+++ b/org.eclipse.tm4e.languageconfiguration/plugin.properties
@@ -22,5 +22,3 @@ LanguageConfiguration.category.name=TM4E Language Configuration
 LanguageConfiguration.addBlockComment.name=Add Block Comment
 LanguageConfiguration.removeBlockComment.name=Remove Block Comment
 LanguageConfiguration.toggleLineComment.name=Toggle Line Comment
-
-LanguageConfiguration.menu.source.name=Source

--- a/org.eclipse.tm4e.languageconfiguration/plugin.xml
+++ b/org.eclipse.tm4e.languageconfiguration/plugin.xml
@@ -115,24 +115,23 @@
    <extension point="org.eclipse.ui.menus">
 
       <!-- register commands as entries in main window menu -->
-      <menuContribution locationURI="menu:org.eclipse.ui.main.menu?after=edit">
-         <menu id="org.eclipse.tm4e.source.menu" label="%LanguageConfiguration.menu.source.name" mnemonic="S">
-            <command commandId="org.eclipse.tm4e.languageconfiguration.toggleLineCommentCommand" >
-               <visibleWhen>
-                  <reference definitionId="org.eclipse.tm4e.languageconfiguration.hasLanguageConfiguration"/>
-               </visibleWhen>
-             </command>
-             <command commandId="org.eclipse.tm4e.languageconfiguration.addBlockCommentCommand">
-                <visibleWhen>
-                   <reference definitionId="org.eclipse.tm4e.languageconfiguration.hasLanguageConfiguration"/>
-                </visibleWhen>
-             </command>
-             <command commandId="org.eclipse.tm4e.languageconfiguration.removeBlockCommentCommand">
-                <visibleWhen>
-                   <reference definitionId="org.eclipse.tm4e.languageconfiguration.hasLanguageConfiguration"/>
-                </visibleWhen>
-             </command>
-          </menu>
+      <menuContribution locationURI="menu:org.eclipse.tm4e.source.menu?before=contributions">
+         <separator name="commentGroup" visible="true" />
+         <command commandId="org.eclipse.tm4e.languageconfiguration.toggleLineCommentCommand" >
+            <visibleWhen>
+               <reference definitionId="org.eclipse.tm4e.languageconfiguration.hasLanguageConfiguration"/>
+            </visibleWhen>
+         </command>
+         <command commandId="org.eclipse.tm4e.languageconfiguration.addBlockCommentCommand">
+            <visibleWhen>
+               <reference definitionId="org.eclipse.tm4e.languageconfiguration.hasLanguageConfiguration"/>
+            </visibleWhen>
+         </command>
+         <command commandId="org.eclipse.tm4e.languageconfiguration.removeBlockCommentCommand">
+            <visibleWhen>
+               <reference definitionId="org.eclipse.tm4e.languageconfiguration.hasLanguageConfiguration"/>
+            </visibleWhen>
+         </command>
       </menuContribution>
 
       <!-- register commands as entries in editor context menu -->

--- a/org.eclipse.tm4e.languageconfiguration/pom.xml
+++ b/org.eclipse.tm4e.languageconfiguration/pom.xml
@@ -10,5 +10,5 @@
 
 	<artifactId>org.eclipse.tm4e.languageconfiguration</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.5.3-SNAPSHOT</version>
+	<version>0.5.4-SNAPSHOT</version>
 </project>

--- a/org.eclipse.tm4e.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.ui/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tm4e.ui;singleton:=true
-Bundle-Version: 0.6.1.qualifier
+Bundle-Version: 0.6.2.qualifier
 Require-Bundle: org.eclipse.tm4e.core;bundle-version="0.5.1",
  org.eclipse.jface.text,
  org.eclipse.core.runtime,

--- a/org.eclipse.tm4e.ui/plugin.properties
+++ b/org.eclipse.tm4e.ui/plugin.properties
@@ -33,6 +33,7 @@ TextMateGrammarImportWizard.name=TextMate grammar
 TextMateGrammarImportWizard.desc=Import an existing TextMate grammar
 
 # Menu contribution
+menu.source.name=Source
 menu.textmate.theme.label=Switch to Theme...
 
 # Markers

--- a/org.eclipse.tm4e.ui/plugin.xml
+++ b/org.eclipse.tm4e.ui/plugin.xml
@@ -86,6 +86,19 @@
 
    <!-- Contextual Menu -->
    <extension point="org.eclipse.ui.menus">
+
+      <!-- Contribute a "Source" menu entry in the main window menu -->
+      <menuContribution locationURI="menu:org.eclipse.ui.main.menu?after=edit">
+         <menu id="org.eclipse.tm4e.source.menu" label="%menu.source.name" mnemonic="S">
+            <separator name="contributions" visible="true">
+               <!--
+                  because of some bug in Eclipse naming this separator "contributions" instead of "additions".
+                  if it is named "additions" inserting entries at specific locations using e.g. "?after=additions" is not working.
+               -->
+            </separator>
+         </menu>
+      </menuContribution>
+
       <!-- Editor "TextMate" contribution -->
       <menuContribution allPopups="true" locationURI="popup:org.eclipse.ui.popup.any?after=additions">
          <menu id="org.eclipse.tm4e.ui.internal.menus.Theme" label="%menu.textmate.theme.label" >

--- a/org.eclipse.tm4e.ui/pom.xml
+++ b/org.eclipse.tm4e.ui/pom.xml
@@ -10,5 +10,5 @@
 
 	<artifactId>org.eclipse.tm4e.ui</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.6.1-SNAPSHOT</version>
+	<version>0.6.2-SNAPSHOT</version>
 </project>


### PR DESCRIPTION
This allows other plugins to contribute to the menu without depending on the presence of the languageconfiguration plugin