### PR TITLE
fix: Do not create error markers for comments

### DIFF
--- a/org.eclipse.tm4e.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.ui/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tm4e.ui;singleton:=true
-Bundle-Version: 0.6.2.qualifier
+Bundle-Version: 0.6.3.qualifier
 Require-Bundle: org.eclipse.tm4e.core;bundle-version="0.5.2",
  org.eclipse.jface.text,
  org.eclipse.core.runtime,

--- a/org.eclipse.tm4e.ui/pom.xml
+++ b/org.eclipse.tm4e.ui/pom.xml
@@ -10,5 +10,5 @@
 
 	<artifactId>org.eclipse.tm4e.ui</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.6.2-SNAPSHOT</version>
+	<version>0.6.3-SNAPSHOT</version>
 </project>

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/utils/MarkerUtils.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/utils/MarkerUtils.java
@@ -50,7 +50,7 @@ public final class MarkerUtils {
 
 	private static final Map<String, MarkerConfig> MARKERCONFIG_BY_TAG = Map.of(
 			// problem markers:
-			"BUG", MarkerConfig.forProblem(IMarker.SEVERITY_ERROR),
+			"BUG", MarkerConfig.forProblem(IMarker.SEVERITY_INFO),
 			"NOTE", MarkerConfig.forProblem(IMarker.SEVERITY_INFO),
 			// task markers:
 			"FIXME", MarkerConfig.forTask(IMarker.PRIORITY_HIGH),


### PR DESCRIPTION
Otherwise adding a comment to a file like
  // Need to check abc due to BUG 000233
or 
  // This unit tests makes sure BUG 000233 does not happen again

will add error markers to a resource. We have comments like this in our code base, and I do not think the users should see error markers because of them (indeed I think the content of a comment should never create an error marker)
