### PR TITLE
fix: task tags are ignored if not at the start of a comment

### DIFF
--- a/org.eclipse.tm4e.feature/feature.xml
+++ b/org.eclipse.tm4e.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.tm4e.feature"
       label="%featureName"
-      version="0.5.4.qualifier"
+      version="0.5.5.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.tm4e.feature/pom.xml
+++ b/org.eclipse.tm4e.feature/pom.xml
@@ -10,5 +10,5 @@
 
 	<artifactId>org.eclipse.tm4e.feature</artifactId>
 	<packaging>eclipse-feature</packaging>
-	<version>0.5.4-SNAPSHOT</version>
+	<version>0.5.5-SNAPSHOT</version>
 </project>

--- a/org.eclipse.tm4e.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.ui/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tm4e.ui;singleton:=true
-Bundle-Version: 0.6.3.qualifier
+Bundle-Version: 0.6.4.qualifier
 Require-Bundle: org.eclipse.tm4e.core;bundle-version="0.5.2",
  org.eclipse.jface.text,
  org.eclipse.core.runtime,

--- a/org.eclipse.tm4e.ui/pom.xml
+++ b/org.eclipse.tm4e.ui/pom.xml
@@ -10,5 +10,5 @@
 
 	<artifactId>org.eclipse.tm4e.ui</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.6.3-SNAPSHOT</version>
+	<version>0.6.4-SNAPSHOT</version>
 </project>

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/utils/MarkerUtils.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/utils/MarkerUtils.java
@@ -50,7 +50,7 @@ public final class MarkerUtils {
 				MARKERCONFIG_BY_TAG.put(markerConfig.tag, markerConfig);
 			}
 			TAG_SELECTOR_PATTERN = Pattern
-					.compile("^\\s*(" + MARKERCONFIG_BY_TAG.keySet().stream().collect(Collectors.joining("|")) + ")\\b");
+					.compile("\\b(" + MARKERCONFIG_BY_TAG.keySet().stream().collect(Collectors.joining("|")) + ")\\b");
 		}
 	}
 


### PR DESCRIPTION
as of the last release task tags are only evaluated if they are at the beginning of a comment.
this PR restores the previous behaviour of evaluating task tags anywhere in the comment.