### PR TITLE
fix: only add related link to langcfg prefs if langcfg plugin is loaded

### DIFF
--- a/org.eclipse.tm4e.feature/feature.xml
+++ b/org.eclipse.tm4e.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.tm4e.feature"
       label="%featureName"
-      version="0.5.5.qualifier"
+      version="0.5.6.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.tm4e.feature/pom.xml
+++ b/org.eclipse.tm4e.feature/pom.xml
@@ -10,5 +10,5 @@
 
 	<artifactId>org.eclipse.tm4e.feature</artifactId>
 	<packaging>eclipse-feature</packaging>
-	<version>0.5.5-SNAPSHOT</version>
+	<version>0.5.6-SNAPSHOT</version>
 </project>

--- a/org.eclipse.tm4e.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.ui/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tm4e.ui;singleton:=true
-Bundle-Version: 0.6.4.qualifier
+Bundle-Version: 0.6.5.qualifier
 Require-Bundle: org.eclipse.tm4e.core;bundle-version="0.5.2",
  org.eclipse.jface.text,
  org.eclipse.core.runtime,

--- a/org.eclipse.tm4e.ui/pom.xml
+++ b/org.eclipse.tm4e.ui/pom.xml
@@ -10,5 +10,5 @@
 
 	<artifactId>org.eclipse.tm4e.ui</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.6.4-SNAPSHOT</version>
+	<version>0.6.5-SNAPSHOT</version>
 </project>

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/preferences/TextMatePreferencePage.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/preferences/TextMatePreferencePage.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.tm4e.ui.internal.preferences;
 
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jface.preference.PreferencePage;
 import org.eclipse.swt.SWT;
@@ -41,9 +42,11 @@ public final class TextMatePreferencePage extends PreferencePage implements IWor
 		addRelatedLink(composite, GrammarPreferencePage.PAGE_ID, TMUIMessages.TextMatePreferencePage_GrammarRelatedLink);
 
 		// Add link to language configuration preference page
-		addRelatedLink(composite,
-				"org.eclipse.tm4e.languageconfiguration.preferences.LanguageConfigurationPreferencePage", //$NON-NLS-1$
-				TMUIMessages.TextMatePreferencePage_LanguageConfigurationRelatedLink);
+		if (Platform.getBundle("org.eclipse.tm4e.languageconfiguration") != null) { //$NON-NLS-1$
+			addRelatedLink(composite,
+					"org.eclipse.tm4e.languageconfiguration.preferences.LanguageConfigurationPreferencePage", //$NON-NLS-1$
+					TMUIMessages.TextMatePreferencePage_LanguageConfigurationRelatedLink);
+		}
 
 		// Add link to task tags preference page
 		addRelatedLink(composite, TaskTagsPreferencePage.PAGE_ID, TMUIMessages.TextMatePreferencePage_TaskTagsRelatedLink);


### PR DESCRIPTION
Fixes #475 