### PR TITLE
fix: Layout of Language Configuration Preference Page #552

### DIFF
--- a/org.eclipse.tm4e.languageconfiguration/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.languageconfiguration/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tm4e.languageconfiguration;singleton:=true
-Bundle-Version: 0.5.5.qualifier
+Bundle-Version: 0.5.6.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.jface.text,
  org.eclipse.ui.genericeditor,

--- a/org.eclipse.tm4e.languageconfiguration/pom.xml
+++ b/org.eclipse.tm4e.languageconfiguration/pom.xml
@@ -10,5 +10,5 @@
 
 	<artifactId>org.eclipse.tm4e.languageconfiguration</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.5.5-SNAPSHOT</version>
+	<version>0.5.6-SNAPSHOT</version>
 </project>

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/preferences/LanguageConfigurationPreferencePage.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/preferences/LanguageConfigurationPreferencePage.java
@@ -92,7 +92,7 @@ public final class LanguageConfigurationPreferencePage extends PreferencePage im
 		innerLayout.marginHeight = 0;
 		innerLayout.marginWidth = 0;
 		innerParent.setLayout(innerLayout);
-		final var gd = new GridData(GridData.FILL_BOTH);
+		final var gd = new GridData(SWT.FILL, SWT.FILL, true, false);
 		gd.horizontalSpan = 2;
 		innerParent.setLayoutData(gd);
 


### PR DESCRIPTION
innerParent was grabbing all the excess vertical space. Changed to layout data to do not grab excess vertical space. #552 