### PR TITLE
build(deps): Build against new Orbit and Platform

### DIFF
--- a/org.eclipse.tm4e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.core/META-INF/MANIFEST.MF
@@ -4,11 +4,11 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tm4e.core
-Bundle-Version: 0.6.0.qualifier
+Bundle-Version: 0.6.1.qualifier
 Require-Bundle: org.apache.batik.css;bundle-version="[1.9.1,2.0.0)";resolution:=optional,
  org.apache.batik.util;bundle-version="[1.9.1,2.0.0)";resolution:=optional,
  com.google.gson;bundle-version="[2.10.1,3.0.0)",
- com.google.guava;bundle-version="[30.1.0,31.0.0)",
+ com.google.guava;bundle-version="[32.0.0,33.0.0)",
  org.jcodings;bundle-version="[1.0.57,2.0.0)",
  org.joni;bundle-version="[2.2.1,3.0.0)",
  org.yaml.snakeyaml;bundle-version="[2.0.0,3.0.0)"

--- a/org.eclipse.tm4e.core/pom.xml
+++ b/org.eclipse.tm4e.core/pom.xml
@@ -10,7 +10,7 @@
 
 	<artifactId>org.eclipse.tm4e.core</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.6.0-SNAPSHOT</version>
+	<version>0.6.1-SNAPSHOT</version>
 
 	<profiles>
 		<profile>

--- a/org.eclipse.tm4e.feature/feature.xml
+++ b/org.eclipse.tm4e.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.tm4e.feature"
       label="%featureName"
-      version="0.6.0.qualifier"
+      version="0.6.1.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.tm4e.feature/pom.xml
+++ b/org.eclipse.tm4e.feature/pom.xml
@@ -10,5 +10,5 @@
 
 	<artifactId>org.eclipse.tm4e.feature</artifactId>
 	<packaging>eclipse-feature</packaging>
-	<version>0.6.0-SNAPSHOT</version>
+	<version>0.6.1-SNAPSHOT</version>
 </project>

--- a/org.eclipse.tm4e.languageconfiguration/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.languageconfiguration/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tm4e.languageconfiguration;singleton:=true
-Bundle-Version: 0.5.6.qualifier
+Bundle-Version: 0.5.7.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.jface.text,
  org.eclipse.ui.genericeditor,

--- a/org.eclipse.tm4e.languageconfiguration/pom.xml
+++ b/org.eclipse.tm4e.languageconfiguration/pom.xml
@@ -10,5 +10,5 @@
 
 	<artifactId>org.eclipse.tm4e.languageconfiguration</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.5.6-SNAPSHOT</version>
+	<version>0.5.7-SNAPSHOT</version>
 </project>

--- a/org.eclipse.tm4e.markdown/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.markdown/META-INF/MANIFEST.MF
@@ -4,12 +4,12 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tm4e.markdown;singleton:=true
-Bundle-Version: 0.5.2.qualifier
+Bundle-Version: 0.5.3.qualifier
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.tm4e.core;bundle-version="0.6.0",
  org.eclipse.tm4e.registry;bundle-version="0.6.4",
  org.eclipse.tm4e.ui;bundle-version="0.7.0",
- com.google.guava;bundle-version="[30.1.0,31.0.0)"
+ com.google.guava;bundle-version="[32.0.0,33.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.tm4e.markdown,
  org.eclipse.tm4e.markdown.marked

--- a/org.eclipse.tm4e.markdown/pom.xml
+++ b/org.eclipse.tm4e.markdown/pom.xml
@@ -10,5 +10,5 @@
 
 	<artifactId>org.eclipse.tm4e.markdown</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.5.2-SNAPSHOT</version>
+	<version>0.5.3-SNAPSHOT</version>
 </project>

--- a/org.eclipse.tm4e.registry/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.registry/META-INF/MANIFEST.MF
@@ -3,12 +3,12 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.tm4e.registry;singleton:=true
-Bundle-Version: 0.6.4.qualifier
+Bundle-Version: 0.6.5.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.tm4e.core;bundle-version="0.6.0",
  org.eclipse.core.runtime,
  com.google.gson;bundle-version="[2.10.1,3.0.0)",
- com.google.guava;bundle-version="[30.1.0,31.0.0)",
+ com.google.guava;bundle-version="[32.0.0,33.0.0)",
  org.eclipse.equinox.preferences
 Export-Package: org.eclipse.tm4e.registry
 Bundle-Activator: org.eclipse.tm4e.registry.TMEclipseRegistryPlugin

--- a/org.eclipse.tm4e.registry/pom.xml
+++ b/org.eclipse.tm4e.registry/pom.xml
@@ -10,5 +10,5 @@
 
 	<artifactId>org.eclipse.tm4e.registry</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.6.4-SNAPSHOT</version>
+	<version>0.6.5-SNAPSHOT</version>
 </project>

--- a/org.eclipse.tm4e.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.ui/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tm4e.ui;singleton:=true
-Bundle-Version: 0.7.0.qualifier
+Bundle-Version: 0.7.1.qualifier
 Require-Bundle: org.eclipse.tm4e.core;bundle-version="0.6.0",
  org.eclipse.jface.text,
  org.eclipse.core.runtime,
@@ -14,7 +14,7 @@ Require-Bundle: org.eclipse.tm4e.core;bundle-version="0.6.0",
  org.eclipse.tm4e.registry;bundle-version="0.6.4",
  org.eclipse.ui.ide;resolution:=optional,
  com.google.gson;bundle-version="[2.10.1,3.0.0)",
- com.google.guava;bundle-version="[30.1.0,31.1.0)",
+ com.google.guava;bundle-version="[32.0.0,33.0.0)",
  org.eclipse.e4.ui.css.swt.theme,
  org.eclipse.core.expressions,
  org.eclipse.ui.workbench.texteditor,

--- a/org.eclipse.tm4e.ui/pom.xml
+++ b/org.eclipse.tm4e.ui/pom.xml
@@ -10,5 +10,5 @@
 
 	<artifactId>org.eclipse.tm4e.ui</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.7.0-SNAPSHOT</version>
+	<version>0.7.1-SNAPSHOT</version>
 </project>

--- a/target-platform/tm4e-target.target
+++ b/target-platform/tm4e-target.target
@@ -7,11 +7,10 @@
             <repository location="https://download.eclipse.org/cbi/updates/license"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="com.google.guava" version="30.1.0.v20221112-0806"/>
-            <unit id="com.google.gson" version="2.10.1.v20230109-0753"/>
+            <unit id="com.google.guava" version="32.1.1.jre"/>
+            <unit id="com.google.gson" version="2.10.1"/>
             <unit id="org.apache.batik.css" version="1.16.0.v20221027-0840"/>
-            <!-- R20230302014618 = Eclipse 2023-03 -->
-            <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20230302014618/repository"/>
+            <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2023-09"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
@@ -21,29 +20,29 @@
             <unit id="junit-jupiter-api" version="0.0.0"/>
             <unit id="org.eclipse.jdt.junit5.runtime" version="0.0.0"/>
             <unit id="org.eclipse.ui.trace" version="0.0.0"/>
-            <!-- 4.27 = Eclipse 2023-03 -->
-            <repository location="https://download.eclipse.org/eclipse/updates/4.27/"/>
+            <!-- 4.28 = Eclipse 2023-06 -->
+            <repository location="https://download.eclipse.org/eclipse/updates/4.28/"/>
         </location>
-        <location includeDependencyDepth="direct" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
-            <dependencies>
-                <dependency>
-                    <groupId>org.yaml</groupId>
-                    <artifactId>snakeyaml</artifactId>
-                    <version>2.0</version>
-                    <type>jar</type>
-                 </dependency>
-             </dependencies>
-        </location>
-        <location includeDependencyDepth="direct" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
-            <dependencies>
-                <dependency>
-                    <groupId>org.jruby.joni</groupId>
-                    <artifactId>joni</artifactId>
-                    <version>2.2.1</version>
-                    <type>jar</type>
-                </dependency>
-            </dependencies>
-            <instructions><![CDATA[
+	    <location includeDependencyDepth="direct" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
+		    <dependencies>
+			    <dependency>
+				    <groupId>org.yaml</groupId>
+				    <artifactId>snakeyaml</artifactId>
+				    <version>2.0</version>
+				    <type>jar</type>
+			    </dependency>
+		    </dependencies>
+	    </location>
+	    <location includeDependencyDepth="direct" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
+		    <dependencies>
+			    <dependency>
+				    <groupId>org.jruby.joni</groupId>
+				    <artifactId>joni</artifactId>
+				    <version>2.2.1</version>
+				    <type>jar</type>
+			    </dependency>
+		    </dependencies>
+		    <instructions><![CDATA[
 Bundle-Name:           Bundle derived from maven artifact ${mvnGroupId}:${mvnArtifactId}:${mvnVersion}
 version:               ${version_cleanup;${mvnVersion}}
 Bundle-SymbolicName:   org.${mvnArtifactId}
@@ -52,7 +51,7 @@ Import-Package:        *;resolution:=optional
 Export-Package:        *;version="${version}";-noimport:=true
 DynamicImport-Package: *
 ]]></instructions>
-        </location>
+	    </location>
     </locations>
     <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 </target>


### PR DESCRIPTION
Mainly to pick up Guava 32.x to get rid of
https://nvd.nist.gov/vuln/detail/CVE-2023-2976

Version bumps as needed.