### PR TITLE
fix: Include guava in p2 repository

### DIFF
--- a/org.eclipse.tm4e.repository/category.xml
+++ b/org.eclipse.tm4e.repository/category.xml
@@ -18,6 +18,9 @@
    <bundle id="com.google.gson" version="0.0.0">
       <category name="Dependencies"/>
    </bundle>
+   <bundle id="com.google.guava" version="0.0.0">
+      <category name="Dependencies"/>
+   </bundle>
    <bundle id="org.apache.batik.constants" version="0.0.0">
       <category name="Dependencies"/>
    </bundle>


### PR DESCRIPTION
Project uses guava directly so it makes sense to include it in our p2 repo so plugin can be installed on barebone Eclipse IDE even.