### PR TITLE
fix: Content Type selector of Language Configuration Wizard is empty #582

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,6 +124,7 @@ jobs:
           --batch-mode \
           --show-version \
           -Dtycho.disableP2Mirrors=true \
+          -Dsurefire.rerunFailingTestsCount=3 \
           $maven_args \
           ${{ github.event.inputs.additional_maven_args }} \
           clean verify

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,9 +24,11 @@ pipeline {
 				withMaven(maven:'apache-maven-latest', mavenLocalRepo: '$WORKSPACE/.m2/repository') {
 				withCredentials([string(credentialsId: 'gpg-passphrase', variable: 'KEYRING_PASSPHRASE')]) {
 				wrap([$class: 'Xvnc', useXauthority: true]) {
-					sh 'mvn clean verify \
+					sh '''mvn clean verify \
 						-Dmaven.test.failure.ignore=true \
-						-Psign -Dgpg.passphrase="${KEYRING_PASSPHRASE}"'
+						-Dsurefire.rerunFailingTestsCount=3 \
+						-Psign -Dgpg.passphrase="${KEYRING_PASSPHRASE}"
+					'''
 				}}}
 			}
 			post {

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/wizards/SelectLanguageConfigurationWizardPage.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/wizards/SelectLanguageConfigurationWizardPage.java
@@ -8,6 +8,7 @@
  *
  * Contributors:
  * Lucas Bullen (Red Hat Inc.) - initial API and implementation
+ * Sebastian Thomschke (Vegard IT GmbH) - fixed content type selection
  */
 package org.eclipse.tm4e.languageconfiguration.internal.wizards;
 
@@ -229,7 +230,7 @@ final class SelectLanguageConfigurationWizardPage extends WizardPage implements 
 			final var elements = new ArrayList<>();
 			final var baseType = (IContentType) parentElement;
 			for (final var contentType : manager.getAllContentTypes()) {
-				if (Objects.equals(baseType, contentType)) {
+				if (Objects.equals(baseType, contentType.getBaseType())) {
 					elements.add(contentType);
 				}
 			}
@@ -252,7 +253,7 @@ final class SelectLanguageConfigurationWizardPage extends WizardPage implements 
 
 		@Override
 		public Object[] getElements(@Nullable final Object inputElement) {
-			return getChildren(null);
+			return getChildren(manager.getContentType(IContentTypeManager.CT_TEXT));
 		}
 
 		@Override


### PR DESCRIPTION
![image](https://github.com/eclipse/tm4e/assets/426959/6d46603b-d4bb-4e71-a102-9231f6f3063c)
