### PR TITLE
feat: Lookup grammars with "langpck." scope name prefix if not found

### DIFF
--- a/org.eclipse.tm4e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tm4e.core
-Bundle-Version: 0.6.1.qualifier
+Bundle-Version: 0.6.2.qualifier
 Require-Bundle: com.google.gson;bundle-version="[2.10.1,3.0.0)",
  com.google.guava;bundle-version="[32.1.0,33.0.0)",
  org.apache.batik.css;bundle-version="[1.16.0,2.0.0)";resolution:=optional,

--- a/org.eclipse.tm4e.core/pom.xml
+++ b/org.eclipse.tm4e.core/pom.xml
@@ -10,7 +10,7 @@
 
 	<artifactId>org.eclipse.tm4e.core</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.6.1-SNAPSHOT</version>
+	<version>0.6.2-SNAPSHOT</version>
 
 	<profiles>
 		<profile>

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/registry/SyncRegistry.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/registry/SyncRegistry.java
@@ -38,7 +38,7 @@ import org.eclipse.tm4e.core.internal.theme.Theme;
 public final class SyncRegistry implements IGrammarRepository, IThemeProvider {
 
 	private final Map<String, Grammar> _grammars = new HashMap<>();
-	private final Map<String, IRawGrammar> _rawGrammars = new HashMap<>();
+	private final Map<String, @Nullable IRawGrammar> _rawGrammars = new HashMap<>();
 	private final Map<String, Collection<String>> _injectionGrammars = new HashMap<>();
 	private Theme _theme;
 
@@ -68,7 +68,14 @@ public final class SyncRegistry implements IGrammarRepository, IThemeProvider {
 	@Override
 	@Nullable
 	public IRawGrammar lookup(final String scopeName) {
-		return this._rawGrammars.get(scopeName);
+		var grammar = this._rawGrammars.get(scopeName);
+
+		// check if tm4e language pack is installed, e.g. "source.python" -> "lngpck.source.python"
+		if (grammar == null && !scopeName.startsWith("lngpck.")) {
+			grammar = this._rawGrammars.get("lngpck." + scopeName);
+		}
+
+		return grammar;
 	}
 
 	@Override

--- a/org.eclipse.tm4e.registry/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.registry/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.tm4e.registry;singleton:=true
-Bundle-Version: 0.6.5.qualifier
+Bundle-Version: 0.6.6.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.equinox.preferences,

--- a/org.eclipse.tm4e.registry/pom.xml
+++ b/org.eclipse.tm4e.registry/pom.xml
@@ -10,5 +10,5 @@
 
 	<artifactId>org.eclipse.tm4e.registry</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.6.5-SNAPSHOT</version>
+	<version>0.6.6-SNAPSHOT</version>
 </project>

--- a/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/internal/GrammarCache.java
+++ b/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/internal/GrammarCache.java
@@ -11,6 +11,8 @@
  */
 package org.eclipse.tm4e.registry.internal;
 
+import static org.eclipse.tm4e.core.internal.utils.NullSafetyHelper.castNullable;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -61,7 +63,14 @@ final class GrammarCache {
 	 */
 	@Nullable
 	IGrammarDefinition getDefinition(final String scopeName) {
-		return definitions.get(scopeName);
+		var grammar = castNullable(definitions.get(scopeName));
+
+		// check if tm4e language pack is installed, e.g. "source.python" -> "lngpck.source.python"
+		if (grammar == null && !scopeName.startsWith("lngpck.")) {
+			grammar = definitions.get("lngpck." + scopeName);
+		}
+
+		return grammar;
 	}
 
 	/**


### PR DESCRIPTION
The tm4e language pack plugin registers all languages with a `langpck.` scope name prefix. If a grammar references, for example, `scope.python`, the grammar registered by the language pack will not be found, resulting in `WARNING: CANNOT find grammar for scopeName [source.python]`. With this commit the language will automatically be looked up via `langpck.source.python` as a fallback.