### PR TITLE
fix: handle grammar registrations to the same scope by different plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Local work folder that is not checked in
+_LOCAL/
+
 # Eclipse
 /bin
 /*/bin

--- a/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/GrammarDefinition.java
+++ b/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/GrammarDefinition.java
@@ -13,6 +13,7 @@ package org.eclipse.tm4e.registry;
 
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tm4e.registry.internal.TMScope;
 
 /**
  * Grammar definition defined by the "org.eclipse.tm4e.registry.grammars"
@@ -31,8 +32,8 @@ import org.eclipse.jdt.annotation.Nullable;
  */
 public class GrammarDefinition extends TMResource implements IGrammarDefinition {
 
-	@Nullable
-	private String scopeName;
+	private String scopeName = "<set-by-gson>";
+	private transient @Nullable ITMScope scope;
 
 	/**
 	 * Constructor for user preferences (loaded from Json with Gson).
@@ -40,11 +41,6 @@ public class GrammarDefinition extends TMResource implements IGrammarDefinition 
 	public GrammarDefinition() {
 	}
 
-	/**
-	 * Constructor for extension point.
-	 *
-	 * @param scopeName
-	 */
 	public GrammarDefinition(final String scopeName, final String path) {
 		super(path);
 		this.scopeName = scopeName;
@@ -56,8 +52,11 @@ public class GrammarDefinition extends TMResource implements IGrammarDefinition 
 	}
 
 	@Override
-	public String getScopeName() {
-		assert scopeName != null;
-		return scopeName;
+	public ITMScope getScope() {
+		ITMScope scope = this.scope;
+		if (scope == null) {
+			this.scope = scope = new TMScope(scopeName, getPluginId());
+		}
+		return scope;
 	}
 }

--- a/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/IGrammarDefinition.java
+++ b/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/IGrammarDefinition.java
@@ -13,14 +13,11 @@ package org.eclipse.tm4e.registry;
 
 /**
  * TextMate grammar definition API.
- *
  */
 public interface IGrammarDefinition extends ITMResource {
 
 	/**
-	 * Returns the scope name of the TextMate grammar.
-	 *
-	 * @return the scope name of the TextMate grammar.
+	 * @return the scope of the TextMate grammar.
 	 */
-	String getScopeName();
+	ITMScope getScope();
 }

--- a/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/IGrammarRegistryManager.java
+++ b/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/IGrammarRegistryManager.java
@@ -12,7 +12,6 @@
 package org.eclipse.tm4e.registry;
 
 import java.util.Collection;
-import java.util.List;
 
 import org.eclipse.core.runtime.content.IContentType;
 import org.eclipse.jdt.annotation.Nullable;
@@ -65,7 +64,7 @@ public interface IGrammarRegistryManager {
 	 * @return the {@link IGrammar} for the given scope name and null otherwise.
 	 */
 	@Nullable
-	IGrammar getGrammarForScope(String scopeName);
+	IGrammar getGrammarForScope(ITMScope scope);
 
 	/**
 	 * <b>NOTE:</b> This method can be very expensive as it potentially results in eagerly loading of all registered grammar files,
@@ -82,7 +81,7 @@ public interface IGrammarRegistryManager {
 	 * @return the list of content types bound with the given scope name and null otherwise.
 	 */
 	@Nullable
-	List<IContentType> getContentTypesForScope(String scopeName);
+	Collection<IContentType> getContentTypesForScope(ITMScope scope);
 
 	/**
 	 * @return list of scope names to inject for the given <code>scopeName</code> and null otherwise.

--- a/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/ITMScope.java
+++ b/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/ITMScope.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2023 Sebastian Thomschke and others.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * - Sebastian Thomschke - initial API and implementation
+ */
+package org.eclipse.tm4e.registry;
+
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * TextMate grammar scope API
+ */
+public interface ITMScope {
+
+	String getName();
+
+	String getQualifiedName();
+
+	@Nullable
+	String getPluginId();
+
+	boolean isQualified();
+}

--- a/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/WorkingCopyGrammarRegistryManager.java
+++ b/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/WorkingCopyGrammarRegistryManager.java
@@ -40,8 +40,8 @@ public class WorkingCopyGrammarRegistryManager extends AbstractGrammarRegistryMa
 	}
 
 	@Override
-	public @Nullable List<IContentType> getContentTypesForScope(String scopeName) {
-		return manager.getContentTypesForScope(scopeName);
+	public @Nullable Collection<IContentType> getContentTypesForScope(ITMScope scope) {
+		return manager.getContentTypesForScope(scope);
 	}
 
 	@Override

--- a/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/internal/GrammarRegistryManager.java
+++ b/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/internal/GrammarRegistryManager.java
@@ -82,7 +82,7 @@ public final class GrammarRegistryManager extends AbstractGrammarRegistryManager
 								.warn("No content-type found with id='" + contentTypeId + "', ignoring TM4E association.");
 					} else {
 						final String scopeName = ce.getAttribute(XMLConstants.SCOPE_NAME_ATTR);
-						registerContentTypeToScopeBinding(contentType, scopeName);
+						registerContentTypeToScopeBinding(ce.getNamespaceIdentifier(), contentType, scopeName);
 					}
 					break;
 				}
@@ -94,13 +94,13 @@ public final class GrammarRegistryManager extends AbstractGrammarRegistryManager
 		final var definitions = PreferenceHelper.loadGrammars();
 		if (definitions != null) {
 			for (final IGrammarDefinition definition : definitions) {
-				userDefinitions.put(definition.getScopeName(), definition);
+				userDefinitions.add(definition);
 			}
 		}
 	}
 
 	@Override
 	public void save() throws BackingStoreException {
-		PreferenceHelper.saveGrammars(userDefinitions.values());
+		PreferenceHelper.saveGrammars(userDefinitions.stream().toList());
 	}
 }

--- a/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/internal/TMScope.java
+++ b/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/internal/TMScope.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2023 Sebastian Thomschke and others.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * - Sebastian Thomschke - initial API and implementation
+ */
+package org.eclipse.tm4e.registry.internal;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tm4e.registry.ITMScope;
+
+public final class TMScope implements ITMScope {
+	private final @Nullable String pluginId; // e.g. "com.example.myplugin"
+	private final String name; // e.g. "source.batchfile"
+	private final String qualifiedName; //e.g. "source.batchfile@com.example.myplugin"
+
+	public TMScope(String scopeName, @Nullable String pluginId) {
+		this.name = scopeName;
+		this.pluginId = pluginId;
+		qualifiedName = pluginId == null ? scopeName : scopeName + '@' + pluginId;
+	}
+
+	@Override
+	public boolean equals(@Nullable Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null || getClass() != obj.getClass())
+			return false;
+		final TMScope other = (TMScope) obj;
+		return qualifiedName.equals(other.qualifiedName);
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public @Nullable String getPluginId() {
+		return pluginId;
+	}
+
+	@Override
+	public String getQualifiedName() {
+		return qualifiedName;
+	}
+
+	@Override
+	public int hashCode() {
+		return qualifiedName.hashCode();
+	}
+
+	@Override
+	public boolean isQualified() {
+		return pluginId != null;
+	}
+
+	@Override
+	public String toString() {
+		return qualifiedName;
+	}
+}

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/preferences/GrammarPreferencePage.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/preferences/GrammarPreferencePage.java
@@ -250,25 +250,20 @@ public final class GrammarPreferencePage extends PreferencePage implements IWork
 			}
 
 			private void selectGrammar(final IGrammarDefinition definition) {
-				final String scopeName = definition.getScopeName();
-				// Fill "General" tab
-				fillGeneralTab(scopeName);
-				// Fill "Content type" tab
-				fillContentTypeTab(scopeName);
-				// Fill "Theme" tab
+				fillGeneralTab(definition);
+				fillContentTypeTab(definition);
 				final IThemeAssociation selectedAssociation = fillThemeTab(definition);
-				// Fill preview
-				fillPreview(scopeName, selectedAssociation);
+				fillPreview(definition, selectedAssociation);
 			}
 
-			private void fillGeneralTab(final String scopeName) {
-				final IGrammar grammar = grammarRegistryManager.getGrammarForScope(scopeName);
+			private void fillGeneralTab(final IGrammarDefinition definition) {
+				final IGrammar grammar = grammarRegistryManager.getGrammarForScope(definition.getScope());
 				grammarInfoWidget.refresh(grammar);
 			}
 
-			private void fillContentTypeTab(final String scopeName) {
+			private void fillContentTypeTab(final IGrammarDefinition definition) {
 				// Load the content type binding for the given grammar
-				contentTypesWidget.setInput(grammarRegistryManager.getContentTypesForScope(scopeName));
+				contentTypesWidget.setInput(grammarRegistryManager.getContentTypesForScope(definition.getScope()));
 			}
 
 			@Nullable
@@ -293,15 +288,15 @@ public final class GrammarPreferencePage extends PreferencePage implements IWork
 				return selectedAssociation;
 			}
 
-			private void fillPreview(final String scopeName, @Nullable final IThemeAssociation selectedAssociation) {
+			private void fillPreview(final IGrammarDefinition definition, @Nullable final IThemeAssociation selectedAssociation) {
 				// Preview the grammar
-				final IGrammar grammar = grammarRegistryManager.getGrammarForScope(scopeName);
+				final IGrammar grammar = grammarRegistryManager.getGrammarForScope(definition.getScope());
 				if (selectedAssociation != null) {
 					setPreviewTheme(selectedAssociation.getThemeId());
 				}
 				previewViewer.setGrammar(grammar);
 				// Snippet
-				final ISnippet[] snippets = snippetManager.getSnippets(scopeName);
+				final ISnippet[] snippets = snippetManager.getSnippets(definition.getScope().getName());
 				if (snippets.length == 0) {
 					previewViewer.setText("");
 				} else {
@@ -333,8 +328,7 @@ public final class GrammarPreferencePage extends PreferencePage implements IWork
 			wizard.setGrammarRegistryManager(grammarRegistryManager);
 			final var dialog = new WizardDialog(getShell(), wizard);
 			if (dialog.open() == Window.OK) {
-				// User grammar was saved, refresh the list of grammar and
-				// select the created grammar.
+				// User grammar was saved, refresh the list of grammar and select the created grammar.
 				final IGrammarDefinition created = wizard.getCreatedDefinition();
 				grammarViewer.refresh();
 				grammarViewer.setSelection(new StructuredSelection(created));

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/preferences/ThemePreferencePage.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/preferences/ThemePreferencePage.java
@@ -347,12 +347,12 @@ public final class ThemePreferencePage extends PreferencePage implements IWorkbe
 		final IGrammarDefinition definition = (IGrammarDefinition) selection.getFirstElement();
 
 		// Preview the grammar
-		final IGrammar grammar = grammarRegistryManager.getGrammarForScope(definition.getScopeName());
+		final IGrammar grammar = grammarRegistryManager.getGrammarForScope(definition.getScope());
 		previewViewer.setTheme(theme);
 		previewViewer.setGrammar(grammar);
 
 		// Snippet
-		final ISnippet[] snippets = TMUIPlugin.getSnippetManager().getSnippets(definition.getScopeName());
+		final ISnippet[] snippets = TMUIPlugin.getSnippetManager().getSnippets(definition.getScope().getName());
 		if (snippets.length == 0) {
 			previewViewer.setText("");
 		} else {

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/widgets/GrammarDefinitionLabelProvider.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/widgets/GrammarDefinitionLabelProvider.java
@@ -39,10 +39,9 @@ public final class GrammarDefinitionLabelProvider extends LabelProvider implemen
 		if (element == null)
 			return "";
 
-		final IGrammarDefinition definition = (IGrammarDefinition) element;
-
+		final var definition = (IGrammarDefinition) element;
 		return switch (columnIndex) {
-			case 0 -> definition.getScopeName();
+			case 0 -> definition.getScope().getName();
 			case 1 -> definition.getPath();
 			case 2 -> definition.getPluginId();
 			default -> "";

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/widgets/ThemeAssociationsWidget.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/widgets/ThemeAssociationsWidget.java
@@ -112,7 +112,7 @@ public final class ThemeAssociationsWidget extends TableAndButtonsWidget {
 			return new IThemeAssociation[0];
 		}
 		final IThemeAssociation[] themeAssociations = themeManager
-				.getThemeAssociationsForScope(definition.getScopeName());
+				.getThemeAssociationsForScope(definition.getScope().getName());
 		// Refresh the list of associations
 		super.setInput(themeAssociations);
 		// Select the first of given association

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/wizards/CreateThemeAssociationWizardPage.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/wizards/CreateThemeAssociationWizardPage.java
@@ -133,7 +133,7 @@ final class CreateThemeAssociationWizardPage extends AbstractWizardPage {
 	IThemeAssociation getThemeAssociation() {
 		final String themeId = ((ITheme) themeViewer.getStructuredSelection().getFirstElement()).getId();
 		final String scopeName = ((IGrammarDefinition) grammarViewer.getStructuredSelection()
-				.getFirstElement()).getScopeName();
+				.getFirstElement()).getScope().getName();
 		final boolean whenDark = whenDarkButton.getSelection();
 		return new ThemeAssociation(themeId, scopeName, whenDark);
 	}


### PR DESCRIPTION
Without this change grammar registrations from different plugins sharing the same scope name could unpredictably overwrite each other.

With this change, grammars are registered using fully qualified scope names (scopeName + '@' + pluginId). If plugin A supplies a content-type-to-scope and registers a grammar to that scope, it is ensured that if another plugin B also registers a grammar using the same scope, there won't be accidental usage of the plugin B's grammar via plugin A's content-type-to-scope binding.

The change also makes multiple grammar registrations for the same scope visible in the Preferences>TextMate>Grammars table.

![image](https://github.com/eclipse/tm4e/assets/426959/fc0d51b5-ed00-4b9f-8192-917c61690e6e)
