### PR TITLE
build: set version to 0.9.0 and change versioning scheme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,21 +68,25 @@ docker exec -u root -it $container_id /bin/bash
 
 ### ⬆️ Version bump
 
-tm4e tries to use OSGi Semantic Version (to properly expose its API contracts and breakage) and Reproducible Version Qualifiers (to minimize the avoid producing multiple equivalent artifacts for identical source).
-This requires the developer to manually bump version from time to time. Somes rules are that:
+The TM4E project adopts [Semantic Versioning](https://semver.org/) on release level, ensuring the proper exposure of API contracts and addressing potential breakages.
 
-* Versions are bumped on a __per module grain__ (bump version of individual bundles/features one by one when necessary), __DON'T bump version of parent pom, nor of other modules you don't change__
-* __Versions are bumped maximum once per release__ (don't bump versions that were already bumped since last release)
-* __Don't bump versions of what you don't change__
-* __Bump version of the bundles you're modifying only if it's their 1st change since last release__
-* Version bump may need to be cascaded to features that *include* the artifact you just changed, and then to features that *include* such features and so on (unless the version of those features were already bumped since last release).
+To alleviate confusion among end-users regarding the effectively installed TM4E release and to ease the development process and troubleshooting, starting with version **0.9.0**, individual TM4E features/plugins are no longer versioned independently (OSGi semantic versioning).
+Instead, they are aligned with the overall TM4E release version, following a practice that is common in other Eclipse Platform projects, such as EGit or Mylyn, as well as popular projects outside the Eclipse Platform universe, like the Spring Application Framework.
 
-The delta for version bumps are:
+In this versioning approach, when any plugin introduces new features necessitating a minor version increment, the versions of **all** TM4E plugins/features are updated collectively, and the next release version will be adjusted accordingly.
 
-* `+0.0.1` (next micro) for a bugfix, or an internal change that doesn't surface to APIs
-* `+0.1.0` (next minor) for an API addition
-* `+1.0.0` (next major) for an API breakage (needs to be discussed on the mailing-list first)
-* If some "smaller" bump already took place, you can replace it with your "bigger one". Eg, if last release has org.eclipse.tm4e 0.4.1; and someone already bumped version to 0.4.2 (for an internal change) and you're adding a new API, then you need to change version to 0.5.0.
+To simplify version increments, utilize the `bump-versions.py` Python script located in the root project directory.
+This script facilitates the recursive update of the project version and plugin dependencies in all relevant files, including `pom.xml`, `feature.xml`, and `META-INF/MANIFEST.MF`.
+
+The usage is as follows:
+```bash
+$ python bump-version.py (major|minor|micro)
+```
+
+Where
+* `micro` (`+0.0.1`) is for a backward compatible bugfix, or an internal change that doesn't surface to APIs
+* `minor` (`+0.1.0`) is for a backward compatible API or feature addition
+* `major` (`+1.0.0`) is for an API breakage (needs to be discussed on the mailing-list first)
 
 ### ➕ Submit changes
 

--- a/bump-version.py
+++ b/bump-version.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# Copyright (c) 2023 Sebastian Thomschke and others.
+# SPDX-License-Identifier: EPL-2.0
+
+import re, os, sys
+
+MIN_PYTHON_VERSION = (3, 10)
+if sys.version_info < MIN_PYTHON_VERSION:
+    print(f'ERROR: This script requires at least Python {".".join(map(str, MIN_PYTHON_VERSION))} but found Python {".".join(map(str, sys.version_info[0:2]))}.')
+    sys.exit(1)
+
+if not len(sys.argv) == 2:
+    print("Recursively bumps the project version in all pom.xml, feature.xml and META-INF/MANIFEST.MF files")
+    print()
+    print("USAGE: python bump-version.py (major|minor|micro)")
+    sys.exit(1)
+
+
+def increment_version(version:str, level:str):
+    match = re.match(r'^(\d+)\.(\d+)\.(\d+)$', version)
+    assert match, f'Unparseable version: {version}'
+
+    major = int(match.group(1))
+    minor = int(match.group(2))
+    patch = int(match.group(3))
+    match level.casefold():
+        case 'major':
+            major += 1
+            minor = 0
+            patch = 0
+        case 'minor':
+            minor += 1
+            patch = 0
+        case 'micro' | 'patch':
+            patch += 1
+        case _:
+            raise RuntimeError(f'Unknown version upgrade level: {level}. Available are: major, minor, patch')
+
+    return f'{major}.{minor}.{patch}'
+
+
+THIS_FILE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+print(f"Determine current version...")
+with open(os.path.join(THIS_FILE_DIR, "pom.xml"), "rt", encoding = 'utf-8') as fh:
+    content = fh.read()
+    old_version = re.search(r"<version>(\d+\.\d+\.\d+)-SNAPSHOT</version", content).group(1)
+    assert old_version, "Cannot determine version in root pom.xml"
+print(f"Current version: {old_version}")
+new_version = increment_version(old_version, sys.argv[1])
+print(f"New version: {new_version}")
+
+for root, dirs, files in os.walk(THIS_FILE_DIR):
+    dirs[:] = [d for d in dirs if not d.startswith('.') and not d == "target" ]  # exclude hidden dirs and "target" dirs
+
+    for file in files:
+        match file:
+            case 'pom.xml':
+                filepath = os.path.join(root, file)
+                print(f"Updating [{filepath}]...")
+                with open(filepath, "rt", encoding = 'utf-8') as fh:
+                    content = fh.read()
+                    content = content.replace(f"<version>{old_version}-SNAPSHOT</version>", f"<version>{new_version}-SNAPSHOT</version>")
+                with open(filepath, "wt", encoding = 'utf-8') as fh:
+                    fh.write(content)
+
+            case 'MANIFEST.MF':
+                if root.endswith("META-INF"):
+                    filepath = os.path.join(root, file)
+                    print(f"Updating [{filepath}]...")
+                    with open(filepath, "rt", encoding = 'utf-8') as fh:
+                        content = fh.read()
+                        content = content.replace(f"Bundle-Version: {old_version}.qualifier", f"Bundle-Version: {new_version}.qualifier", 1)
+                        content = re.sub(r'(org[.]eclipse[.]tm4e[.].+;bundle-version=")([^"]+)(")', rf'\g<1>{new_version}\g<3>', content)
+                    with open(filepath, "wt", encoding = 'utf-8') as fh:
+                        fh.write(content)
+
+            case 'feature.xml':
+                    filepath = os.path.join(root, file)
+                    print(f"Updating [{filepath}]...")
+                    with open(filepath, "rt", encoding = 'utf-8') as fh:
+                        content = fh.read()
+                        content = re.sub(r'(version=")([0-9.]+)(.qualifier")', rf'\g<1>{new_version}\g<3>', content)
+                    with open(filepath, "wt", encoding = 'utf-8') as fh:
+                        fh.write(content)

--- a/org.eclipse.tm4e.core.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.core.tests/META-INF/MANIFEST.MF
@@ -4,10 +4,10 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tm4e.core.tests;singleton:=true
-Bundle-Version: 0.5.1.qualifier
-Require-Bundle: org.apache.batik.css;bundle-version="1.7.0";resolution:=optional,
- org.apache.batik.util;bundle-version="1.7.0";resolution:=optional,
- com.google.gson;bundle-version="2.9.0";resolution:=optional,
+Bundle-Version: 0.9.0.qualifier
+Require-Bundle: org.apache.batik.css;resolution:=optional,
+ org.apache.batik.util;resolution:=optional,
+ com.google.gson;resolution:=optional,
  org.eclipse.core.runtime,
  org.eclipse.tm4e.core
 Import-Package: org.junit.runner,

--- a/org.eclipse.tm4e.core.tests/pom.xml
+++ b/org.eclipse.tm4e.core.tests/pom.xml
@@ -5,12 +5,11 @@
 	<parent>
 		<groupId>org.eclipse</groupId>
 		<artifactId>org.eclipse.tm4e</artifactId>
-		<version>0.3.2-SNAPSHOT</version>
+		<version>0.9.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.tm4e.core.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
-	<version>0.5.1-SNAPSHOT</version>
 
 	<build>
 		<pluginManagement>

--- a/org.eclipse.tm4e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tm4e.core
-Bundle-Version: 0.6.2.qualifier
+Bundle-Version: 0.9.0.qualifier
 Require-Bundle: com.google.gson;bundle-version="[2.10.1,3.0.0)",
  org.apache.batik.css;bundle-version="[1.16.0,2.0.0)";resolution:=optional,
  org.apache.batik.util;bundle-version="[1.16.0,2.0.0)";resolution:=optional,

--- a/org.eclipse.tm4e.core/pom.xml
+++ b/org.eclipse.tm4e.core/pom.xml
@@ -5,12 +5,11 @@
 	<parent>
 		<groupId>org.eclipse</groupId>
 		<artifactId>org.eclipse.tm4e</artifactId>
-		<version>0.3.2-SNAPSHOT</version>
+		<version>0.9.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.tm4e.core</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.6.2-SNAPSHOT</version>
 
 	<profiles>
 		<profile>

--- a/org.eclipse.tm4e.feature/feature.xml
+++ b/org.eclipse.tm4e.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.tm4e.feature"
       label="%featureName"
-      version="0.6.2.qualifier"
+      version="0.9.0.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.tm4e.feature/pom.xml
+++ b/org.eclipse.tm4e.feature/pom.xml
@@ -5,10 +5,9 @@
 	<parent>
 		<groupId>org.eclipse</groupId>
 		<artifactId>org.eclipse.tm4e</artifactId>
-		<version>0.3.2-SNAPSHOT</version>
+		<version>0.9.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.tm4e.feature</artifactId>
 	<packaging>eclipse-feature</packaging>
-	<version>0.6.2-SNAPSHOT</version>
 </project>

--- a/org.eclipse.tm4e.language_pack.feature/feature.xml
+++ b/org.eclipse.tm4e.language_pack.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.tm4e.language_pack.feature"
       label="%featureName"
-      version="0.3.0.qualifier"
+      version="0.9.0.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.tm4e.language_pack.feature/pom.xml
+++ b/org.eclipse.tm4e.language_pack.feature/pom.xml
@@ -5,10 +5,9 @@
 	<parent>
 		<groupId>org.eclipse</groupId>
 		<artifactId>org.eclipse.tm4e</artifactId>
-		<version>0.3.2-SNAPSHOT</version>
+		<version>0.9.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.tm4e.language_pack.feature</artifactId>
 	<packaging>eclipse-feature</packaging>
-	<version>0.3.0-SNAPSHOT</version>
 </project>

--- a/org.eclipse.tm4e.language_pack/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.language_pack/META-INF/MANIFEST.MF
@@ -4,10 +4,10 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tm4e.language_pack;singleton:=true
-Bundle-Version: 0.3.0.qualifier
-Require-Bundle: org.eclipse.tm4e.ui;bundle-version="[0.1.0,2.0.0)",
- org.eclipse.tm4e.registry;bundle-version="[0.1.0,2.0.0)",
- org.eclipse.tm4e.languageconfiguration;bundle-version="[0.1.0,2.0.0)",
+Bundle-Version: 0.9.0.qualifier
+Require-Bundle: org.eclipse.tm4e.ui;bundle-version="0.9.0",
+ org.eclipse.tm4e.registry;bundle-version="0.9.0",
+ org.eclipse.tm4e.languageconfiguration;bundle-version="0.9.0",
  org.eclipse.ui.editors;bundle-version="[3.3.0,4.0.0)",
  org.eclipse.ui.genericeditor;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.core.contenttype;bundle-version="[3.2.0,4.0.0)"

--- a/org.eclipse.tm4e.language_pack/pom.xml
+++ b/org.eclipse.tm4e.language_pack/pom.xml
@@ -5,10 +5,9 @@
 	<parent>
 		<groupId>org.eclipse</groupId>
 		<artifactId>org.eclipse.tm4e</artifactId>
-		<version>0.3.2-SNAPSHOT</version>
+		<version>0.9.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.tm4e.language_pack</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.3.0-SNAPSHOT</version>
 </project>

--- a/org.eclipse.tm4e.language_pack/updater/pom.xml
+++ b/org.eclipse.tm4e.language_pack/updater/pom.xml
@@ -9,7 +9,7 @@
    <parent>
       <groupId>org.eclipse</groupId>
       <artifactId>org.eclipse.tm4e</artifactId>
-      <version>0.3.2-SNAPSHOT</version>
+      <version>0.9.0-SNAPSHOT</version>
       <relativePath>../..</relativePath>
    </parent>
 

--- a/org.eclipse.tm4e.languageconfiguration.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.languageconfiguration.tests/META-INF/MANIFEST.MF
@@ -2,20 +2,20 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for TM4E language configuration support
 Bundle-SymbolicName: org.eclipse.tm4e.languageconfiguration.tests;singleton:=true
-Bundle-Version: 0.5.2.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse TM4E
 Automatic-Module-Name: org.eclipse.tm4e.languageconfiguration.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Require-Bundle: org.junit;bundle-version="4.12.0",
- org.eclipse.tm4e.languageconfiguration,
- org.eclipse.ui.genericeditor;bundle-version="1.1",
- org.eclipse.core.runtime,
+Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,
+ org.eclipse.jface.text,
+ org.eclipse.ui,
+ org.eclipse.ui.editors,
+ org.eclipse.ui.genericeditor,
  org.eclipse.ui.ide,
  org.eclipse.ui.workbench,
- org.eclipse.ui.editors,
  org.eclipse.ui.workbench.texteditor,
- org.eclipse.jface.text;bundle-version="3.19",
- org.eclipse.ui
+ org.eclipse.tm4e.languageconfiguration,
+ org.junit
 Bundle-ActivationPolicy: lazy
 Import-Package: org.junit.jupiter.api

--- a/org.eclipse.tm4e.languageconfiguration.tests/pom.xml
+++ b/org.eclipse.tm4e.languageconfiguration.tests/pom.xml
@@ -5,11 +5,10 @@
 	<parent>
 		<groupId>org.eclipse</groupId>
 		<artifactId>org.eclipse.tm4e</artifactId>
-		<version>0.3.2-SNAPSHOT</version>
+		<version>0.9.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.tm4e.languageconfiguration.tests</artifactId>
-	<version>0.5.2-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 
 	<build>

--- a/org.eclipse.tm4e.languageconfiguration/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.languageconfiguration/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tm4e.languageconfiguration;singleton:=true
-Bundle-Version: 0.5.8.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.expressions,
  org.eclipse.core.filebuffers,
@@ -17,9 +17,9 @@ Require-Bundle: org.eclipse.core.expressions,
  org.eclipse.ui.genericeditor,
  org.eclipse.ui.ide,
  org.eclipse.e4.ui.css.swt.theme,
- org.eclipse.tm4e.registry;bundle-version="0.6.6",
- org.eclipse.tm4e.core;bundle-version="0.6.2",
- org.eclipse.tm4e.ui;bundle-version="0.7.2",
+ org.eclipse.tm4e.registry;bundle-version="0.9.0",
+ org.eclipse.tm4e.core;bundle-version="0.9.0",
+ org.eclipse.tm4e.ui;bundle-version="0.9.0",
  com.google.gson;bundle-version="[2.10.1,3.0.0)"
 Bundle-Activator: org.eclipse.tm4e.languageconfiguration.LanguageConfigurationPlugin
 Export-Package: org.eclipse.tm4e.languageconfiguration,

--- a/org.eclipse.tm4e.languageconfiguration/pom.xml
+++ b/org.eclipse.tm4e.languageconfiguration/pom.xml
@@ -5,10 +5,9 @@
 	<parent>
 		<groupId>org.eclipse</groupId>
 		<artifactId>org.eclipse.tm4e</artifactId>
-		<version>0.3.2-SNAPSHOT</version>
+		<version>0.9.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.tm4e.languageconfiguration</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.5.8-SNAPSHOT</version>
 </project>

--- a/org.eclipse.tm4e.markdown/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.markdown/META-INF/MANIFEST.MF
@@ -4,11 +4,11 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tm4e.markdown;singleton:=true
-Bundle-Version: 0.5.4.qualifier
+Bundle-Version: 0.9.0.qualifier
 Require-Bundle: org.eclipse.core.runtime,
- org.eclipse.tm4e.core;bundle-version="0.6.2",
- org.eclipse.tm4e.registry;bundle-version="0.6.6",
- org.eclipse.tm4e.ui;bundle-version="0.7.2"
+ org.eclipse.tm4e.core;bundle-version="0.9.0",
+ org.eclipse.tm4e.registry;bundle-version="0.9.0",
+ org.eclipse.tm4e.ui;bundle-version="0.9.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.tm4e.markdown,
  org.eclipse.tm4e.markdown.marked

--- a/org.eclipse.tm4e.markdown/pom.xml
+++ b/org.eclipse.tm4e.markdown/pom.xml
@@ -5,10 +5,9 @@
 	<parent>
 		<groupId>org.eclipse</groupId>
 		<artifactId>org.eclipse.tm4e</artifactId>
-		<version>0.3.2-SNAPSHOT</version>
+		<version>0.9.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.tm4e.markdown</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.5.4-SNAPSHOT</version>
 </project>

--- a/org.eclipse.tm4e.registry/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.registry/META-INF/MANIFEST.MF
@@ -3,11 +3,11 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.tm4e.registry;singleton:=true
-Bundle-Version: 0.6.6.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.equinox.preferences,
- org.eclipse.tm4e.core;bundle-version="0.6.1",
+ org.eclipse.tm4e.core;bundle-version="0.9.0",
  com.google.gson;bundle-version="[2.10.1,3.0.0)"
 Export-Package: org.eclipse.tm4e.registry
 Bundle-Activator: org.eclipse.tm4e.registry.TMEclipseRegistryPlugin

--- a/org.eclipse.tm4e.registry/pom.xml
+++ b/org.eclipse.tm4e.registry/pom.xml
@@ -5,10 +5,9 @@
 	<parent>
 		<groupId>org.eclipse</groupId>
 		<artifactId>org.eclipse.tm4e</artifactId>
-		<version>0.3.2-SNAPSHOT</version>
+		<version>0.9.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.tm4e.registry</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.6.6-SNAPSHOT</version>
 </project>

--- a/org.eclipse.tm4e.repository/pom.xml
+++ b/org.eclipse.tm4e.repository/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse</groupId>
 		<artifactId>org.eclipse.tm4e</artifactId>
-		<version>0.3.2-SNAPSHOT</version>
+		<version>0.9.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.tm4e.repository</artifactId>

--- a/org.eclipse.tm4e.samples/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.samples/META-INF/MANIFEST.MF
@@ -4,14 +4,14 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tm4e.samples;singleton:=true
-Bundle-Version: 0.4.2.qualifier
+Bundle-Version: 0.9.0.qualifier
 Require-Bundle: org.eclipse.jface.text,
  org.eclipse.core.runtime,
  org.eclipse.ui,
  org.eclipse.ui.editors,
- org.eclipse.tm4e.core;bundle-version="0.5.2",
- org.eclipse.tm4e.ui;bundle-version="0.6.2",
- org.eclipse.ui.genericeditor;bundle-version="1.0.0";resolution:=optional
+ org.eclipse.ui.genericeditor;bundle-version="1.0.0";resolution:=optional,
+ org.eclipse.tm4e.core;bundle-version="0.9.0",
+ org.eclipse.tm4e.ui;bundle-version="0.9.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.eclipse.tm4e.samples

--- a/org.eclipse.tm4e.samples/pom.xml
+++ b/org.eclipse.tm4e.samples/pom.xml
@@ -4,10 +4,9 @@
 	<parent>
 		<groupId>org.eclipse</groupId>
 		<artifactId>org.eclipse.tm4e</artifactId>
-		<version>0.3.2-SNAPSHOT</version>
+		<version>0.9.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.tm4e.samples</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.4.2-SNAPSHOT</version>
 </project>

--- a/org.eclipse.tm4e.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.ui.tests/META-INF/MANIFEST.MF
@@ -4,25 +4,24 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tm4e.ui.tests;singleton:=true
-Bundle-Version: 0.7.0.qualifier
-Require-Bundle: org.eclipse.tm4e.core,
- org.eclipse.jface.text,
+Bundle-Version: 0.9.0.qualifier
+Require-Bundle: org.eclipse.jface.text,
+ org.eclipse.core.filesystem,
+ org.eclipse.core.resources,
  org.eclipse.core.runtime,
  org.eclipse.ui,
- org.eclipse.core.resources,
- org.eclipse.core.filesystem,
- com.google.gson;bundle-version="2.9.0",
- org.eclipse.tm4e.ui,
- org.junit,
- junit-jupiter-api,
- org.opentest4j,
+ org.eclipse.ui.editors,
  org.eclipse.ui.genericeditor;resolution:=optional,
  org.eclipse.ui.ide,
- org.eclipse.ui.tests.harness;bundle-version="1.4.0",
+ org.eclipse.ui.tests.harness,
+ org.eclipse.tm4e.core,
  org.eclipse.tm4e.registry,
- org.eclipse.ui.editors
+ org.eclipse.tm4e.ui,
+ com.google.gson;bundle-version="[2.10.1,3.0.0)",
+ org.junit,
+ junit-jupiter-api,
+ org.opentest4j
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.core.filebuffers
 Automatic-Module-Name: org.eclipse.tm4e.ui.tests
-

--- a/org.eclipse.tm4e.ui.tests/pom.xml
+++ b/org.eclipse.tm4e.ui.tests/pom.xml
@@ -5,12 +5,11 @@
 	<parent>
 		<groupId>org.eclipse</groupId>
 		<artifactId>org.eclipse.tm4e</artifactId>
-		<version>0.3.2-SNAPSHOT</version>
+		<version>0.9.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.tm4e.ui.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
-	<version>0.7.0-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.tm4e.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.ui/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tm4e.ui;singleton:=true
-Bundle-Version: 0.7.2.qualifier
+Bundle-Version: 0.9.0.qualifier
 Require-Bundle: org.eclipse.core.expressions,
  org.eclipse.core.filesystem,
  org.eclipse.core.resources,
@@ -15,8 +15,8 @@ Require-Bundle: org.eclipse.core.expressions,
  org.eclipse.ui.trace;resolution:=optional,
  org.eclipse.ui.workbench.texteditor,
  org.eclipse.e4.ui.css.swt.theme,
- org.eclipse.tm4e.core;bundle-version="0.6.2",
- org.eclipse.tm4e.registry;bundle-version="0.6.6",
+ org.eclipse.tm4e.core;bundle-version="0.9.0",
+ org.eclipse.tm4e.registry;bundle-version="0.9.0",
  com.google.gson;bundle-version="[2.10.1,3.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.tm4e.ui,
@@ -32,4 +32,3 @@ Bundle-Activator: org.eclipse.tm4e.ui.TMUIPlugin
 Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.core.filebuffers
 Automatic-Module-Name: org.eclipse.tm4e.ui
-

--- a/org.eclipse.tm4e.ui/pom.xml
+++ b/org.eclipse.tm4e.ui/pom.xml
@@ -5,10 +5,9 @@
 	<parent>
 		<groupId>org.eclipse</groupId>
 		<artifactId>org.eclipse.tm4e</artifactId>
-		<version>0.3.2-SNAPSHOT</version>
+		<version>0.9.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.tm4e.ui</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.7.2-SNAPSHOT</version>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.eclipse</groupId>
 	<artifactId>org.eclipse.tm4e</artifactId>
-	<version>0.3.2-SNAPSHOT</version>
+	<version>0.9.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<prerequisites>
@@ -70,7 +70,7 @@
 						<artifact>
 							<groupId>org.eclipse.tm4e</groupId>
 							<artifactId>tm4e-target</artifactId>
-							<version>0.3.2-SNAPSHOT</version>
+							<version>0.9.0-SNAPSHOT</version>
 						</artifact>
 					</target>
 				</configuration>

--- a/target-platform/pom.xml
+++ b/target-platform/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse</groupId>
 		<artifactId>org.eclipse.tm4e</artifactId>
-		<version>0.3.2-SNAPSHOT</version>
+		<version>0.9.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.eclipse.tm4e</groupId>


### PR DESCRIPTION
With this PR all feature/plugin versions are set to the same value **0.9.0** and the **Version Bump** section of [CONTRIBUTING.md](https://github.com/eclipse/tm4e/pull/652/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055) file is adjusted accordingly.