### PR TITLE
fix: Prevent .txt files being associated with wrong content types

### DIFF
--- a/org.eclipse.tm4e.language_pack/plugin.xml
+++ b/org.eclipse.tm4e.language_pack/plugin.xml
@@ -9,7 +9,8 @@
     <content-type id="org.eclipse.tm4e.language_pack.basetype"
       base-type="org.eclipse.core.runtime.text"
       name="Text (Syntax Highlighting)"
-      priority="low" />
+      priority="low"
+      file-names="WORKAROUND_SO_THAT_THIS_CONTENTTYPE_IS_NOT_ASSOCIATED_WITH_TXT_FILES_SEE_ISSUE_703" />
   </extension>
 
   <!-- use "Generic Text Editor" for all contributes languages -->
@@ -679,7 +680,7 @@
   <!-- ======================================== -->
   <extension point="org.eclipse.core.contenttype.contentTypes">
     <content-type id="org.eclipse.tm4e.language_pack.cpp_embedded_latex" name="C++ embedded Latex" base-type="org.eclipse.tm4e.language_pack.basetype" priority="low"
-                   />
+                  file-names="WORKAROUND_SO_THAT_THIS_CONTENTTYPE_IS_NOT_ASSOCIATED_WITH_TXT_FILES_SEE_ISSUE_703" />
   </extension>
   <extension point="org.eclipse.tm4e.registry.grammars">
     <grammar scopeName="source.cpp.embedded.latex" path="syntaxes/latex/cpp_embedded_latex.tmLanguage.json" />
@@ -715,7 +716,7 @@
   <!-- ======================================== -->
   <extension point="org.eclipse.core.contenttype.contentTypes">
     <content-type id="org.eclipse.tm4e.language_pack.markdown_latex_combined" name="Markdown Latex combined" base-type="org.eclipse.tm4e.language_pack.basetype" priority="low"
-                   />
+                  file-names="WORKAROUND_SO_THAT_THIS_CONTENTTYPE_IS_NOT_ASSOCIATED_WITH_TXT_FILES_SEE_ISSUE_703" />
   </extension>
   <extension point="org.eclipse.tm4e.registry.grammars">
     <grammar scopeName="text.tex.markdown_latex_combined" path="syntaxes/latex/markdown_latex_combined.tmLanguage.json" />
@@ -831,7 +832,7 @@
   <!-- ======================================== -->
   <extension point="org.eclipse.core.contenttype.contentTypes">
     <content-type id="org.eclipse.tm4e.language_pack.markdown-math" name="Markdown Math" base-type="org.eclipse.tm4e.language_pack.basetype" priority="low"
-                   />
+                  file-names="WORKAROUND_SO_THAT_THIS_CONTENTTYPE_IS_NOT_ASSOCIATED_WITH_TXT_FILES_SEE_ISSUE_703" />
   </extension>
   <extension point="org.eclipse.tm4e.registry.grammars">
     <grammar scopeName="text.html.markdown.math" path="syntaxes/markdown-math/markdown-math.tmLanguage.json" />

--- a/org.eclipse.tm4e.language_pack/updater/src/main/java/updater/Updater.java
+++ b/org.eclipse.tm4e.language_pack/updater/src/main/java/updater/Updater.java
@@ -403,12 +403,16 @@ public class Updater {
 				fileExtensions = fileExtensions.stream().distinct().sorted().toList();
 				fileNames = fileNames.stream().distinct().sorted().toList();
 				filePatterns = filePatterns.stream().distinct().sorted().toList();
-
-				templateVars.put("file_associations", Arrays.asList( //
+				final String fileAssociations = Arrays.asList( //
 						fileExtensions.isEmpty() ? null : "file-extensions=\"" + join(fileExtensions, ",") + "\"", //
 						fileNames.isEmpty() ? null : "file-names=\"" + join(fileNames, ",") + "\"", //
 						filePatterns.isEmpty() ? null : "file-patterns=\"" + join(filePatterns, ",") + "\"" //
-				).stream().filter(Objects::nonNull).collect(Collectors.joining(" ")));
+				).stream().filter(Objects::nonNull).collect(Collectors.joining(" "));
+
+				templateVars.put("file_associations",
+						fileAssociations.isBlank()
+								? "file-names=\"WORKAROUND_SO_THAT_THIS_CONTENTTYPE_IS_NOT_ASSOCIATED_WITH_TXT_FILES_SEE_ISSUE_703\""
+								: fileAssociations);
 
 				pluginLines.append(render(
 						"""


### PR DESCRIPTION
This is a - hopefully temporary - workaround for #703 