### PR TITLE
fix: BadLocationExceptions in Colorizer event processing.

### DIFF
--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/text/Colorizer.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/text/Colorizer.java
@@ -67,6 +67,8 @@ class Colorizer {
 			return;
 
 		if (event.model instanceof final ITMDocumentModel docModel) {
+			if (docModel.getDocument() != doc)
+				return;
 			for (final Range range : event.ranges) {
 				try {
 					final int length = doc.getLineOffset(range.toLineNumber - 1) + doc.getLineLength(range.toLineNumber - 1)


### PR DESCRIPTION
The Colorizer should only process events for the document currently present in the viewer. This prevents BadLocationExceptions occurring when the content of the viewer changes rapidly.

<!-- Before submitting a PR, please:
1. read the guidelines for contributions https://github.com/eclipse/tm4e/blob/main/CONTRIBUTING.md
2. ensure you signed the Eclipse Contributor Agreement https://www.eclipse.org/projects/handbook/#contributing-eca
3. prefix the PR title with one of these semantic labels:
   - build:
   - ci:
   - chore:
   - docs:
   - fix:
   - feat:
   - refact:
   - revert:
   - perf:
   - style:
-->
### What does this PR do?
