### PR TITLE
feat: only show the "Source" menu for GenericEditors

### DIFF
--- a/org.eclipse.tm4e.languageconfiguration/plugin.xml
+++ b/org.eclipse.tm4e.languageconfiguration/plugin.xml
@@ -117,6 +117,11 @@
       <!-- register commands as entries in main window menu -->
       <menuContribution locationURI="menu:org.eclipse.ui.main.menu?after=edit">
          <menu id="org.eclipse.tm4e.source.menu" label="%LanguageConfiguration.menu.source.name" mnemonic="S">
+            <visibleWhen>
+               <with variable="activeEditor">
+                  <instanceof value="org.eclipse.ui.internal.genericeditor.ExtensionBasedTextEditor" />
+               </with>
+            </visibleWhen>
             <command commandId="org.eclipse.tm4e.languageconfiguration.toggleLineCommentCommand" >
                <visibleWhen>
                   <reference definitionId="org.eclipse.tm4e.languageconfiguration.hasLanguageConfiguration"/>


### PR DESCRIPTION
This avoids displaying multiple "Source" menus, e.g. in case the a Java
file is opened via the JDT UI plugin which contributes it's own "Source"
menu.

![image](https://github.com/user-attachments/assets/e773a742-faff-4f1c-8677-38875a0ad707)
