### PR TITLE
ci: test with macOS 13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,10 +64,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: 
-        # https://github.com/actions/runner-images#available-images
+        os:  # https://github.com/actions/runner-images#available-images
         - ubuntu-latest
-        - macos-12 # Intel
+        - macos-13 # Intel
         - macos-14 # ARM
         - windows-latest
         target-platform:


### PR DESCRIPTION
macOS 12 image is deprecated and will be removed from GHA beginning December