### PR TITLE
build: remove source features deprecated in tycho 5

### DIFF
--- a/org.eclipse.tm4e.repository/category.xml
+++ b/org.eclipse.tm4e.repository/category.xml
@@ -3,17 +3,11 @@
    <feature id="org.eclipse.tm4e.feature">
       <category name="TextMate"/>
    </feature>
-   <feature id="org.eclipse.tm4e.feature.source">
-      <category name="Sources"/>
-   </feature>
    <feature id="org.eclipse.tm4e.language_pack.feature">
       <category name="TextMate"/>
    </feature>
    <bundle id="org.eclipse.tm4e.samples" version="0.0.0">
       <category name="Samples"/>
-   </bundle>
-   <bundle id="org.eclipse.tm4e.samples.source" version="0.0.0">
-      <category name="Sources"/>
    </bundle>
    <bundle id="com.google.gson" version="0.0.0">
       <category name="Dependencies"/>
@@ -38,6 +32,5 @@
    </bundle>
    <category-def name="TextMate" label="TextMate"/>
    <category-def name="Samples" label="Samples"/>
-   <category-def name="Sources" label="Sources"/>
    <category-def name="Dependencies" label="Dependencies"/>
 </site>

--- a/org.eclipse.tm4e.repository/pom.xml
+++ b/org.eclipse.tm4e.repository/pom.xml
@@ -15,6 +15,21 @@
 		<maven.deploy.skip>true</maven.deploy.skip>
 	</properties>
 
+	<build>
+		<plugins>
+			<plugin>
+				<!-- https://tycho.eclipseprojects.io/doc/main/tycho-p2-repository-plugin/plugin-info.html -->
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-repository-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<!-- see https://github.com/eclipse-tycho/tycho/discussions/5265#discussioncomment-14262476 -->
+					<includeAllSources>true</includeAllSources>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
 	<profiles>
 		<profile>
 			<id>sign</id>

--- a/pom.xml
+++ b/pom.xml
@@ -201,13 +201,6 @@
 				<version>${tycho-version}</version>
 				<executions>
 					<execution>
-						<id>feature-source</id>
-						<phase>package</phase>
-						<goals>
-							<goal>feature-source</goal>
-						</goals>
-					</execution>
-					<execution>
 						<id>plugin-source</id>
 						<goals>
 							<goal>plugin-source</goal>


### PR DESCRIPTION
This PR addresses:
```
Warning: 769 [WARNING]  Goal 'feature-source' is deprecated: Source features are used for a long time
to include sources in development environments but they where always brittle to use and badly integrated.
As nowadays Tycho/P2 offers better ways to archive similar, the automatic generation of such features is
deprecated and will be removed on the next release. In cases where this is still required, one should 
replace it with an explicitly maintained source feature in a dedicated module.
```

https://github.com/eclipse-tycho/tycho/discussions/5265