### PR TITLE
fix: make toggle-line-comment independent of on-enter action #946

### DIFF
--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/registry/LanguageConfigurationRegistryManager.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/registry/LanguageConfigurationRegistryManager.java
@@ -134,8 +134,7 @@ public final class LanguageConfigurationRegistryManager extends AbstractLanguage
 	}
 
 	public boolean shouldComment(final IContentType contentType) {
-		final var definition = getDefinition(contentType);
-		return definition != null && definition.isOnEnterEnabled();
+		return getDefinition(contentType) != null;
 	}
 
 	public List<AutoClosingPairConditional> getEnabledAutoClosingPairs(final IContentType contentType) {


### PR DESCRIPTION
Since its not clear why the toggle-line-comment action has a dependency upon the on-enter action, this condition should be removed, because its not obvious to the user why the toggle-line-comment action does not work, when the on-enter action has been disabled for a certain language.

fixes #946

<!-- Before submitting a PR, please:
1. read the guidelines for contributions https://github.com/eclipse-tm4e/tm4e/blob/main/CONTRIBUTING.md
2. ensure you signed the Eclipse Contributor Agreement https://www.eclipse.org/projects/handbook/#contributing-eca
3. prefix the PR title with one of these semantic labels:
   - build:
   - ci:
   - chore:
   - docs:
   - fix:
   - feat:
   - refact:
   - revert:
   - perf:
   - style:
-->
### What does this PR do?
