### PR TITLE
fix: keep Tab-as-spaces indentation on blank lines (LangCfg)

### DIFF
--- a/org.eclipse.tm4e.languageconfiguration.tests/src/main/java/org/eclipse/tm4e/languageconfiguration/tests/TestWhitespaceInsert.java
+++ b/org.eclipse.tm4e.languageconfiguration.tests/src/main/java/org/eclipse/tm4e/languageconfiguration/tests/TestWhitespaceInsert.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2025 Vegard IT GmbH and others.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * - Sebastian Thomschke (Vegard IT) - initial implementation
+ */
+package org.eclipse.tm4e.languageconfiguration.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.tm4e.ui.internal.utils.UI;
+import org.eclipse.ui.ide.IDE;
+import org.eclipse.ui.texteditor.ITextEditor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that inserting whitespace (e.g., Tab-as-spaces) on a blank line is not stripped
+ * when indentation rules are active (issue #949).
+ */
+public class TestWhitespaceInsert {
+
+	@AfterEach
+	public void tearDown() throws Exception {
+		UI.getActivePage().closeAllEditors(false);
+		for (final IProject p : ResourcesPlugin.getWorkspace().getRoot().getProjects()) {
+			p.delete(true, null);
+		}
+	}
+
+	@Test
+	public void testWhitespaceInsertOnBlankLine() throws Exception {
+		final IProject p = ResourcesPlugin.getWorkspace().getRoot().getProject(getClass().getName() + System.currentTimeMillis());
+		p.create(null);
+		p.open(null);
+		final IFile file = p.getFile("whatever.lc-test");
+		file.create(new ByteArrayInputStream(new byte[0]), true, null);
+		final var editor = (ITextEditor) IDE.openEditor(UI.getActivePage(), file);
+		final var text = (StyledText) editor.getAdapter(Control.class);
+
+		// Insert 4 spaces on an empty line: should remain as inserted (not stripped)
+		text.setText("");
+		text.setSelection(0);
+		text.insert("    ");
+		assertThat(text.getText()).isEqualTo("    ");
+
+		// Insert 4 more spaces at end of a whitespace-only line: should append (not stripped)
+		text.setSelection(text.getCharCount());
+		text.insert("    ");
+		assertThat(text.getText()).isEqualTo("        ");
+	}
+}

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/LanguageConfigurationAutoEditStrategy.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/LanguageConfigurationAutoEditStrategy.java
@@ -142,6 +142,16 @@ public class LanguageConfigurationAutoEditStrategy implements IAutoEditStrategy 
 					final var isTargetLineBlank = TextUtils.isBlankLine(doc, lineIndex);
 
 					if (isPastedTextMultiLine || isTargetLineBlank) {
+
+						// Do not auto-reindent single-line whitespace-only inserts (e.g., Tab as spaces on a blank line)
+						// See: https://github.com/eclipse-tm4e/tm4e/issues/949
+						final boolean isWhitespaceOnlySingleLineInsert = !isPastedTextMultiLine
+								&& command.text.chars().allMatch(Character::isWhitespace);
+						if (isWhitespaceOnlySingleLineInsert) {
+							// Keep user-inserted spaces as-is; skip indentation adjustment
+							continue;
+						}
+
 						final var newIndent = registry.getGoodIndentForLine(doc, lineIndex, contentType, IIndentConverter.of(cursorCfg));
 						if (newIndent != null) {
 							final var lineStartOffset = doc.getLineOffset(lineIndex);


### PR DESCRIPTION
Pressing Tab with "Insert spaces for tabs"inserted spaces that were treated like a paste and reindented via `replaceIndent(..., false)`, which returned an empty string and removed the indentation.

Skip reindentation for single-line, whitespace-only inserts so user-inserted spaces are preserved on blank lines. Multi-line pastes and non-whitespaceinserts remain unchanged.
