### PR TITLE
feat: add TextMate document partitioner

### DIFF
--- a/documentation/DOCUMENT_PARTITIONER.md
+++ b/documentation/DOCUMENT_PARTITIONER.md
@@ -1,0 +1,94 @@
+# TM Partitioner (IDocumentPartitioner)
+
+## Overview
+
+- Partitioning ID: `tm4e.partitioning`
+- Partition type naming: `tm4e:<root-scope>` derived from the active TextMate grammar's base root scope.
+  - Examples: `tm4e:text.html`, `tm4e:source.js`, `tm4e:source.css`.
+- Base partition type:
+  - Before a grammar is known, the synthetic base type `tm4e:base` is used.
+  - After activation with a grammar, the base becomes `tm4e:<root-scope>` (for example, HTML base `tm4e:text.html`).
+- Installed automatically by `org.eclipse.tm4e.ui` for any document that resolves a TextMate grammar. It is added as a secondary partitioning and does not replace an editor's default partitioner.
+
+## Partition Semantics
+
+- `computePartitioning(offset, length)` returns regions that cover the entire requested range contiguously. Gaps between known embedded regions are filled with the current base type.
+- `getPartition(offset)` clamps the offset to the valid range `[0, docLength-1]`. Negative offsets resolve to the first region; EOF resolves to the last region.
+- Regions implement `ITMPartitionRegion` (extends `ITypedRegion`) and carry language metadata:
+  - `getGrammarScope()` returns the effective grammar scope such as `source.js` or `text.html`.
+
+## How to Consume from Code
+
+Get partitions from the TM4E partitioner via `IDocumentExtension3`:
+```java
+var ext3 = (IDocumentExtension3) doc;
+var partitioner = ext3.getDocumentPartitioner(org.eclipse.tm4e.ui.text.TMPartitions.TM_PARTITIONING /* or "tm4e.partitioning" */);
+ITypedRegion[] regions = partitioner.computePartitioning(offset, length);
+```
+
+### Example: Content Assist / Feature Code
+
+```java
+import org.eclipse.tm4e.ui.text.ITMPartitionRegion;
+import org.eclipse.tm4e.ui.text.ITMPartitioner;
+import org.eclipse.tm4e.ui.text.TMPartitions;
+
+// ...
+
+IDocument doc = viewer.getDocument();
+if (doc instanceof IDocumentExtension3 ext3) {
+  if (ext3.getDocumentPartitioner(TMPartitions.TM_PARTITIONING) instanceof ITMPartitioner tmPartitioner) {
+    ITypedRegion r = tmPartitioner.getPartition(caretOffset);
+    // Prefer matching by normalized language scope (handles embedded variants)
+    switch(r.getGrammarScope()) {
+      case "source.js":   // offer JavaScript proposals
+      case "source.css":  // offer CSS proposals
+    }
+  }
+}
+```
+
+## Matching by Scope (Recommended)
+
+- Partition type strings are base-root only (for example, `tm4e:source.js`, `tm4e:text.html`). If you need to distinguish embedded variants (for example, JavaScript-in-Markdown), use `ITMPartitionRegion.getGrammarScope()` which carries the normalized full scope (such as `source.js`).
+- For most feature switches, detect the language via the normalized scope name from `getGrammarScope()` as shown in the example. This is stable for families like `source.css`, `source.js`, or `text.html`.
+
+## Mapping to Content Types (Alternative)
+
+- If your feature keys off `IContentType`, translate the partition at the caret offset:
+
+```java
+IContentType[] cts = org.eclipse.tm4e.ui.text.TMPartitions.getContentTypesForOffset(doc, caretOffset);
+```
+
+## Generic Editor Contributions
+
+- Register your feature with the Generic Editor as usual (e.g., content assist, hovers). Inside your implementation, use the code above to query TM4E’s partitioning and branch behavior based on the normalized scope (recommended) or the partition type.
+- You do not need to install a partitioner yourself; `org.eclipse.tm4e.ui` installs it automatically when a grammar exists.
+
+Example plugin.xml (content assist):
+
+```xml
+<extension point="org.eclipse.ui.genericeditor.contentAssistProcessors">
+  <contentAssistProcessor
+      class="com.example.MyTM4EAwareAssist"
+      contentType="org.eclipse.core.runtime.text"
+      targetId="org.eclipse.ui.genericeditor.GenericEditor"/>
+  <!-- partitionType here refers to the editor's default partitioning;
+       to use TM4E partitions, query tm4e.partitioning from your code. -->
+  </extension>
+```
+
+## Utilities
+
+- Check if a document has a TM4E partitioner installed:
+
+```java
+boolean installed = org.eclipse.tm4e.ui.text.TMPartitions.hasPartitioning(doc);
+```
+
+- Convenience to fetch the TM4E partition at an offset (null if none):
+
+```java
+ITypedRegion part = org.eclipse.tm4e.ui.text.TMPartitions.getPartition(doc, caretOffset);
+```

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/Grammar.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/grammar/Grammar.java
@@ -318,7 +318,8 @@ public final class Grammar implements IGrammar, IRuleFactoryHelper {
 					false,
 					null,
 					scopeList,
-					scopeList);
+					scopeList,
+					null);
 		} else {
 			isFirstLine = false;
 			prevState.reset();

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/rule/BeginEndRule.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/rule/BeginEndRule.java
@@ -46,8 +46,8 @@ public final class BeginEndRule extends Rule {
 	BeginEndRule(final RuleId id, final @Nullable String name, final @Nullable String contentName, final String begin,
 			final List<@Nullable CaptureRule> beginCaptures, final @Nullable String end,
 			final List<@Nullable CaptureRule> endCaptures, final boolean applyEndPatternLast,
-			final CompilePatternsResult patterns) {
-		super(id, name, contentName);
+			final CompilePatternsResult patterns, final @Nullable String grammarScope) {
+		super(id, name, contentName, grammarScope);
 		this.begin = new RegExpSource(begin, this.id);
 		this.beginCaptures = beginCaptures;
 		this.end = new RegExpSource(defaultIfNull(end, "\uFFFF"), RuleId.END_RULE);

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/rule/BeginWhileRule.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/rule/BeginWhileRule.java
@@ -44,8 +44,8 @@ public final class BeginWhileRule extends Rule {
 	BeginWhileRule(final RuleId id, final @Nullable String name, final @Nullable String contentName,
 			final String begin, final List<@Nullable CaptureRule> beginCaptures,
 			final String _while, final List<@Nullable CaptureRule> whileCaptures,
-			final CompilePatternsResult patterns) {
-		super(/* $location, */id, name, contentName);
+			final CompilePatternsResult patterns, final @Nullable String grammarScope) {
+		super(/* $location, */id, name, contentName, grammarScope);
 		this.begin = new RegExpSource(begin, this.id);
 		this.beginCaptures = beginCaptures;
 		this.whileCaptures = whileCaptures;

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/rule/CaptureRule.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/rule/CaptureRule.java
@@ -28,8 +28,8 @@ public final class CaptureRule extends Rule {
 	public final RuleId retokenizeCapturedWithRuleId;
 
 	CaptureRule(final RuleId id, final @Nullable String name, final @Nullable String contentName,
-			final RuleId retokenizeCapturedWithRuleId) {
-		super(id, name, contentName);
+			final RuleId retokenizeCapturedWithRuleId, final @Nullable String grammarScope) {
+		super(id, name, contentName, grammarScope);
 		this.retokenizeCapturedWithRuleId = retokenizeCapturedWithRuleId;
 	}
 

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/rule/IncludeOnlyRule.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/rule/IncludeOnlyRule.java
@@ -31,8 +31,8 @@ final class IncludeOnlyRule extends Rule {
 	private @Nullable RegExpSourceList cachedCompiledPatterns;
 
 	IncludeOnlyRule(final RuleId id, final @Nullable String name, final @Nullable String contentName,
-			final CompilePatternsResult patterns) {
-		super(id, name, contentName);
+			final CompilePatternsResult patterns, final @Nullable String grammarScope) {
+		super(id, name, contentName, grammarScope);
 		this.patterns = patterns.patterns;
 		this.hasMissingPatterns = patterns.hasMissingPatterns;
 	}

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/rule/MatchRule.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/rule/MatchRule.java
@@ -32,8 +32,9 @@ public final class MatchRule extends Rule {
 
 	private @Nullable RegExpSourceList cachedCompiledPatterns;
 
-	MatchRule(final RuleId id, final @Nullable String name, final String match, final List<@Nullable CaptureRule> captures) {
-		super(id, name, null);
+	MatchRule(final RuleId id, final @Nullable String name, final String match, final List<@Nullable CaptureRule> captures,
+			final @Nullable String grammarScope) {
+		super(id, name, null, grammarScope);
 		this.match = new RegExpSource(match, this.id);
 		this.captures = captures;
 	}

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/rule/Rule.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/internal/rule/Rule.java
@@ -30,18 +30,22 @@ public abstract class Rule {
 
 	final RuleId id;
 
+	/** The root scopeName of the grammar that defined this rule (e.g., "text.xml"), or null for local rules. */
+	public final @Nullable String grammarScope; // custom tm4e code - not from upstream (for TMPartitioner)
+
 	private final @Nullable String name;
 	private final boolean nameIsCapturing;
 
 	private final @Nullable String contentName;
 	private final boolean contentNameIsCapturing;
 
-	Rule(final RuleId id, final @Nullable String name, final @Nullable String contentName) {
+	Rule(final RuleId id, final @Nullable String name, final @Nullable String contentName, final @Nullable String grammarScope) {
 		this.id = id;
 		this.name = name;
 		this.nameIsCapturing = RegexSource.hasCaptures(name);
 		this.contentName = contentName;
 		this.contentNameIsCapturing = RegexSource.hasCaptures(contentName);
+		this.grammarScope = grammarScope; // custom tm4e code - not from upstream (for TMPartitioner)
 	}
 
 	public @Nullable String getName(final @Nullable CharSequence lineText, final OnigCaptureIndex @Nullable [] captureIndices) {

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/model/TMModel.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/model/TMModel.java
@@ -256,7 +256,7 @@ public abstract class TMModel implements ITMModel {
 				// check if complete line was tokenized
 				if (r.stoppedEarly) {
 					// treat the rest of the line as one default token
-					r.tokens.add(new TMToken(r.actualStopOffset, "", Collections.emptyList()));
+					r.tokens.add(new TMToken(r.actualStopOffset, "", Collections.emptyList(), null));
 					// Use the line's starting state as end state in case of incomplete tokenization
 					r.endState = currLineTokens.startState;
 				}

--- a/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/model/TMToken.java
+++ b/org.eclipse.tm4e.core/src/main/java/org/eclipse/tm4e/core/model/TMToken.java
@@ -32,10 +32,14 @@ public final class TMToken {
 	// public readonly language: string
 	public final List<String> scopes;
 
-	public TMToken(final int startIndex, final String type, final List<String> scopes) {
+	/** Effective grammar root scope for this token (e.g., "source.js"). May be null. */
+	public final @Nullable String grammarScope; // custom tm4e code - not from upstream (for TMPartitioner)
+
+	public TMToken(final int startIndex, final String type, final List<String> scopes, final @Nullable String grammarScope) {
 		this.startIndex = startIndex;
 		this.type = type;
 		this.scopes = scopes;
+		this.grammarScope = grammarScope; // custom tm4e code - not from upstream (for TMPartitioner)
 	}
 
 	@Override

--- a/org.eclipse.tm4e.registry/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.registry/META-INF/MANIFEST.MF
@@ -9,7 +9,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.equinox.preferences,
  org.eclipse.tm4e.core;bundle-version="0.16.1",
  com.google.gson;bundle-version="[2.13.1,3.0.0)"
-Export-Package: org.eclipse.tm4e.registry
+Export-Package: org.eclipse.tm4e.registry,
+ org.eclipse.tm4e.registry.internal;x-friends:="org.eclipse.tm4e.ui"
 Bundle-Activator: org.eclipse.tm4e.registry.TMEclipseRegistryPlugin
 Bundle-Localization: plugin
 Bundle-ActivationPolicy: lazy

--- a/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/internal/TMScope.java
+++ b/org.eclipse.tm4e.registry/src/main/java/org/eclipse/tm4e/registry/internal/TMScope.java
@@ -13,6 +13,7 @@
 package org.eclipse.tm4e.registry.internal;
 
 import static org.eclipse.tm4e.core.internal.utils.ScopeNames.CONTRIBUTOR_SEPARATOR;
+
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tm4e.registry.ITMScope;
 
@@ -20,13 +21,24 @@ public final class TMScope implements ITMScope {
 
 	/**
 	 * @param scopeName fully qualified ("source.batchfile@com.example.myplugin") or unqualified scopeName ("source.batchfile")
+	 *
+	 * @return unqualified scopeName ("source.batchfile")
+	 */
+	public static String toUnqualified(final String scopeName) {
+		final int separatorAt = scopeName.indexOf(CONTRIBUTOR_SEPARATOR);
+		if (separatorAt == -1)
+			return scopeName;
+		return scopeName.substring(0, separatorAt);
+	}
+
+	/**
+	 * @param scopeName fully qualified ("source.batchfile@com.example.myplugin") or unqualified scopeName ("source.batchfile")
 	 */
 	public static TMScope parse(final String scopeName) {
 		final int separatorAt = scopeName.indexOf(CONTRIBUTOR_SEPARATOR);
-		if (separatorAt == -1) {
-			return new TMScope(scopeName, null, scopeName);
-		}
-		return new TMScope(scopeName.substring(0, separatorAt), scopeName.substring(separatorAt + 1), scopeName);
+		return separatorAt == -1
+				? new TMScope(scopeName, null, scopeName)
+				: new TMScope(scopeName.substring(0, separatorAt), scopeName.substring(separatorAt + 1), scopeName);
 	}
 
 	private final @Nullable String pluginId; // e.g. "com.example.myplugin"
@@ -37,14 +49,14 @@ public final class TMScope implements ITMScope {
 	 * @param scopeName the scope name, e.g. "source.batchfile"
 	 * @param pluginId id of the grammar contributing pluginId, e.g. "com.example.myplugin"
 	 */
-	public TMScope(String scopeName, @Nullable String pluginId) {
-		this.name = scopeName;
+	public TMScope(final String scopeName, @Nullable final String pluginId) {
+		name = scopeName;
 		this.pluginId = pluginId;
 		qualifiedName = pluginId == null ? scopeName : scopeName + CONTRIBUTOR_SEPARATOR + pluginId;
 	}
 
 	private TMScope(final String scopeName, final @Nullable String pluginId, final String qualifiedName) {
-		this.name = scopeName;
+		name = scopeName;
 		this.pluginId = pluginId;
 		this.qualifiedName = qualifiedName;
 	}
@@ -53,7 +65,7 @@ public final class TMScope implements ITMScope {
 	public boolean equals(final @Nullable Object obj) {
 		if (this == obj)
 			return true;
-		return obj instanceof TMScope other
+		return obj instanceof final TMScope other
 				&& qualifiedName.equals(other.qualifiedName);
 	}
 

--- a/org.eclipse.tm4e.ui.tests/plugin.xml
+++ b/org.eclipse.tm4e.ui.tests/plugin.xml
@@ -15,6 +15,7 @@
    <extension
          point="org.eclipse.core.contenttype.contentTypes">
       <content-type
+            base-type="org.eclipse.core.runtime.text"
             file-extensions="ts"
             id="org.eclipse.tm4e.ui.tests.testContentType"
             name="Test Content Type for TM4E (typescipt)"

--- a/org.eclipse.tm4e.ui.tests/src/main/java/org/eclipse/tm4e/ui/tests/internal/text/TMPartitionerTest.java
+++ b/org.eclipse.tm4e.ui.tests/src/main/java/org/eclipse/tm4e/ui/tests/internal/text/TMPartitionerTest.java
@@ -1,0 +1,539 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Vegard IT GmbH and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Sebastian Thomschke (Vegard IT) - initial implementation
+ *******************************************************************************/
+package org.eclipse.tm4e.ui.tests.internal.text;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Paths;
+
+import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.ITypedRegion;
+import org.eclipse.tm4e.core.grammar.IGrammar;
+import org.eclipse.tm4e.core.registry.IGrammarSource;
+import org.eclipse.tm4e.core.registry.Registry;
+import org.eclipse.tm4e.ui.internal.model.TMModelManager;
+import org.eclipse.tm4e.ui.internal.text.TMPartitioner;
+import org.eclipse.tm4e.ui.tests.support.TestUtils;
+import org.eclipse.tm4e.ui.text.ITMPartitionRegion;
+import org.eclipse.tm4e.ui.text.TMPartitions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TMPartitionerTest {
+
+	private Registry reg = new Registry();
+	private Document doc;
+	private TMPartitioner partitioner;
+	private IGrammar jsGrammar;
+	private IGrammar mdGrammar;
+
+	@Test
+	void computePartitioningCoversTailAfterLargeAppendWithoutTokenization() throws Exception {
+		// Ensure initial model is ready and fully tokenized (from @BeforeEach)
+		final int oldLen = doc.getLength();
+
+		// Append a large chunk to the end, but do NOT wait for tokenization
+		final var sb = new StringBuilder();
+		for (int i = 0; i < 2000; i++) {
+			sb.append("line ").append(i).append('\n');
+		}
+		doc.replace(oldLen, 0, sb.toString());
+
+		final int newLen = doc.getLength();
+		final ITypedRegion[] parts = partitioner.computePartitioning(0, newLen);
+
+		// Expected: result covers [0,newLen) contiguously, filling untokenized tail with base.
+		int prevEnd = 0;
+		for (final ITypedRegion r : parts) {
+			assertThat(r.getOffset()).isEqualTo(prevEnd);
+			prevEnd = r.getOffset() + r.getLength();
+		}
+		assertThat(prevEnd).as("partitioning should cover entire document length").isEqualTo(newLen);
+	}
+
+	@Test
+	void computePartitioningCoversWholeRange() throws Exception {
+		final int len = doc.getLength();
+		final ITMPartitionRegion[] parts = partitioner.computePartitioning(0, len);
+		assertThat(parts.length).isGreaterThanOrEqualTo(3); // expect base, css, js at least
+
+		// contiguity and coverage
+		int covered = 0;
+		int prevEnd = 0;
+		boolean sawCss = false, sawJs = false;
+		for (final ITMPartitionRegion r : parts) {
+			assertThat(r.getOffset()).isEqualTo(prevEnd);
+			prevEnd = r.getOffset() + r.getLength();
+			covered += r.getLength();
+			if ("tm4e:source.css".equals(r.getType())) {
+				sawCss = true;
+				assertThat(r.getGrammarScope()).isEqualTo("source.css");
+			}
+			if ("tm4e:source.js".equals(r.getType())) {
+				sawJs = true;
+				assertThat(r.getGrammarScope()).isEqualTo("source.js");
+			}
+		}
+		assertThat(prevEnd).isEqualTo(len);
+		assertThat(covered).isEqualTo(len);
+		assertThat(sawCss).isTrue();
+		assertThat(sawJs).isTrue();
+	}
+
+	@Test
+	void computePartitioningFillsGapsForSubrangeAfterAppend() throws Exception {
+		final int oldLen = doc.getLength();
+		final var add = new StringBuilder();
+		for (int i = 0; i < 500; i++) {
+			add.append("extra ").append(i).append('\n');
+		}
+		doc.replace(oldLen, 0, add.toString());
+
+		final int queryOffset = Math.max(0, oldLen - 10);
+		final int queryLen = 250;
+		final int queryEnd = Math.min(doc.getLength(), queryOffset + queryLen);
+		final ITypedRegion[] segs = partitioner.computePartitioning(queryOffset, queryLen);
+
+		int cursor = queryOffset;
+		for (final ITypedRegion r : segs) {
+			assertThat(r.getOffset()).isEqualTo(cursor);
+			cursor = r.getOffset() + r.getLength();
+		}
+		assertThat(cursor).isEqualTo(queryEnd);
+	}
+
+	@Test
+	void computePartitioningHandlesEmptyDocument() throws Exception {
+		// Reuse the shared partitioner/document from setup for consistency
+		doc.set("");
+		final ITypedRegion[] parts = partitioner.computePartitioning(0, 10);
+		assertThat(parts).hasSize(1);
+		assertThat(parts[0].getOffset()).isEqualTo(0);
+		assertThat(parts[0].getLength()).isEqualTo(0);
+	}
+
+	@Test
+	void cssContentIsSinglePartitionRegion() throws Exception {
+		final String text = doc.get();
+		final int styleTagStart = text.indexOf("<style>\n");
+		assertThat(styleTagStart).isGreaterThanOrEqualTo(0);
+		final int styleContent = styleTagStart + "<style>\n".length();
+		final int styleClose = text.indexOf("</style>", styleContent);
+		assertThat(styleClose).isGreaterThan(styleContent);
+
+		final int contentLen = styleClose - styleContent;
+		final ITMPartitionRegion[] parts = partitioner.computePartitioning(styleContent, contentLen);
+		assertThat(parts).hasSize(1);
+		assertThat(parts[0].getType()).isEqualTo("tm4e:source.css");
+		assertThat(parts[0].getGrammarScope()).isEqualTo("source.css");
+	}
+
+	@Test
+	void documentRemoveDoesNotThrowOnNullText() throws Exception {
+		// Remove a single character using Document#remove, which yields a DocumentEvent with null text
+		final int pos = Math.max(0, doc.get().indexOf("<html>") - 1);
+		// IDocument has no remove(); simulate deletion with replace and empty text
+		doc.replace(pos, 1, "");
+
+		// Should not throw; partitioning remains contiguous over new length
+		final int len = doc.getLength();
+		final ITypedRegion[] parts = partitioner.computePartitioning(0, len);
+		int end = 0;
+		for (final ITypedRegion r : parts) {
+			assertThat(r.getOffset()).isEqualTo(end);
+			end = r.getOffset() + r.getLength();
+		}
+		assertThat(end).isEqualTo(len);
+	}
+
+	@Test
+	void editInsideJsLineDoesNotDropJsRemainder() throws Exception {
+		// Extend the <script> block to span multiple lines
+		String text = doc.get();
+		final int scriptClose = text.indexOf("</script>");
+		TestUtils.waitForIdleAfterChange(doc, 3_000, () -> doc.replace(scriptClose, 0, "let a = 1;\nlet b = 2;\n"));
+		text = doc.get();
+
+		final int aIdx = text.indexOf("let a = 1;");
+		final int bIdx = text.indexOf("let b = 2;");
+		assertThat(aIdx).isGreaterThanOrEqualTo(0);
+		assertThat(bIdx).isGreaterThanOrEqualTo(0);
+
+		// Sanity: both lines are JS
+		assertThat(partitioner.getContentType(aIdx)).isEqualTo("tm4e:source.js");
+		assertThat(partitioner.getContentType(bIdx)).isEqualTo("tm4e:source.js");
+
+		// Edit only the first JS line (single-line range within the JS partition)
+		final int numPos = aIdx + "let a = ".length();
+		TestUtils.waitForIdleAfterChange(doc, 3_000, () -> doc.replace(numPos, 1, "3"));
+
+		// After tokenization for the edited line, the next JS line must remain JS
+		assertThat(partitioner.getContentType(bIdx)).isEqualTo("tm4e:source.js");
+	}
+
+	@Test
+	void editsAddDeleteMoveEmbedded() throws Exception {
+		// 1) Add a new CSS block after <body> (single-line block to ensure the changed range covers content)
+		String text = doc.get();
+		final int bodyIdx = text.indexOf("<body>");
+		final String toInsert = "<style>.new { width: 10px; }</style>\n";
+		TestUtils.waitForIdleAfterChange(doc, 3_000,
+				() -> doc.replace(bodyIdx + "<body>\n".length(), 0, toInsert));
+		text = doc.get();
+		final int newCssIdx = text.indexOf(".new");
+		assertThat(newCssIdx).isGreaterThanOrEqualTo(0);
+		assertThat(partitioner.getContentType(newCssIdx)).isEqualTo("tm4e:source.css");
+
+		// 2) Delete the original CSS block (the one containing 'color: red')
+		final int origStyleStart = text.indexOf("<style>\n");
+		final int origStyleEnd = text.indexOf("</style>", origStyleStart) + "</style>".length();
+		if (origStyleStart >= 0) {
+			final int delStart = origStyleStart;
+			final int delLen = origStyleEnd - origStyleStart;
+			TestUtils.waitForIdleAfterChange(doc, 3_000, () -> doc.replace(delStart, delLen, ""));
+		}
+
+		// Ensure the 'color' declaration is gone and the region is base
+		text = doc.get();
+		assertThat(text.indexOf("color: red")).isEqualTo(-1);
+		final int checkBase = Math.max(0, origStyleStart - 1);
+		assertThat(partitioner.getContentType(checkBase)).startsWith(TMPartitioner.scopeToPartitionType("text."));
+
+		// 3) Move the <script> block to after <head>
+		final int scriptStart = text.indexOf("<script>");
+		final int scriptEnd = text.indexOf("</script>", scriptStart) + "</script>".length();
+		final String scriptBlock = text.substring(scriptStart, scriptEnd);
+		{
+			final int delStart = scriptStart;
+			final int delLen = scriptEnd - scriptStart;
+			TestUtils.waitForIdleAfterChange(doc, 3_000, () -> doc.replace(delStart, delLen, ""));
+		}
+		text = doc.get();
+		final int headIdx = text.indexOf("<head>");
+		TestUtils.waitForIdleAfterChange(doc, 3_000,
+				() -> doc.replace(headIdx + "<head>\n".length(), 0, scriptBlock + "\n"));
+		text = doc.get();
+		final int funcIdx = text.indexOf("function x");
+		assertThat(funcIdx).isGreaterThanOrEqualTo(0);
+		assertThat(partitioner.getContentType(funcIdx)).isEqualTo("tm4e:source.js");
+
+		// Ensure tail of document does not contain JS partitions anymore
+		final int tailStart = text.lastIndexOf("</body>");
+		final ITypedRegion[] tailParts = partitioner.computePartitioning(Math.max(0, tailStart), text.length() - Math.max(0, tailStart));
+		assertThat(tailParts).allMatch(r -> !"tm4e:source.js".equals(r.getType()));
+	}
+
+	@Test
+	void getPartitionReturnsLastRegionAtEOFForJavaScript() throws Exception {
+		// Reuse partitioner+doc; switch the shared TM model to JS and use plain JS text
+		final var model = TMModelManager.INSTANCE.connect(doc);
+		model.setGrammar(jsGrammar);
+		partitioner.setGrammar(jsGrammar);
+		doc.set("let a = 1;\n");
+
+		// Trigger activation and wait for initial tokenization
+		partitioner.getPartition(0);
+		TestUtils.waitForModelReady(doc, 5_000);
+
+		final int len = doc.getLength();
+		final ITMPartitionRegion eofRegion = partitioner.getPartition(len);
+		assertThat(eofRegion.getType()).isEqualTo(TMPartitioner.scopeToPartitionType("source.js"));
+		assertThat(eofRegion.getGrammarScope()).isEqualTo("source.js");
+
+		// Negative offset clamps to start and should also be TS
+		final ITMPartitionRegion negRegion = partitioner.getPartition(-100);
+		assertThat(negRegion.getType()).isEqualTo(TMPartitioner.scopeToPartitionType("source.js"));
+		assertThat(negRegion.getGrammarScope()).isEqualTo("source.js");
+	}
+
+	@Test
+	void jsContentIsSinglePartitionRegion() throws Exception {
+		final String text = doc.get();
+		final int scriptTagStart = text.indexOf("<script>\n");
+		assertThat(scriptTagStart).isGreaterThanOrEqualTo(0);
+		final int scriptContent = scriptTagStart + "<script>\n".length();
+		final int scriptClose = text.indexOf("</script>", scriptContent);
+		assertThat(scriptClose).isGreaterThan(scriptContent);
+
+		final int contentLen = scriptClose - scriptContent;
+		final ITMPartitionRegion[] parts = partitioner.computePartitioning(scriptContent, contentLen);
+		assertThat(parts).hasSize(1);
+		assertThat(parts[0].getType()).isEqualTo("tm4e:source.js");
+		assertThat(parts[0].getGrammarScope()).isEqualTo("source.js");
+	}
+
+	@Test
+	void markdownFencedXmlIsSinglePartition() throws Exception {
+		final var mdDoc = new Document("""
+			Prose
+
+			```xml
+			<profiles id=\"p1\">
+			  <profile/>
+			</profiles>
+			```
+			""");
+		final var model = TMModelManager.INSTANCE.connect(mdDoc);
+		model.setGrammar(mdGrammar);
+
+		// Create a partitioner WITHOUT forcing grammar and connect via helper
+		final TMPartitioner p = new TMPartitioner();
+		mdDoc.setDocumentPartitioner(TMPartitions.TM_PARTITIONING, p);
+		p.connect(mdDoc);
+
+		// Trigger activation
+		p.getPartition(0);
+		TestUtils.waitForModelReady(mdDoc, 5_000);
+
+		final String text = mdDoc.get();
+		final int fence = text.indexOf("```xml\n");
+		assertThat(fence).isGreaterThanOrEqualTo(0);
+		final int contentStart = fence + "```xml\n".length();
+		final int fenceClose = text.indexOf("```", contentStart);
+		assertThat(fenceClose).isGreaterThan(contentStart);
+
+		final ITMPartitionRegion[] parts = p.computePartitioning(contentStart, fenceClose - contentStart);
+		assertThat(parts).hasSize(1);
+		assertThat(parts[0].getType()).isEqualTo("tm4e:text.xml");
+		assertThat(parts[0].getGrammarScope()).isEqualTo("text.xml");
+
+		p.disconnect();
+	}
+
+	@Test
+	void markdownFencedJavascriptIsSinglePartition() throws Exception {
+		final var mdDoc = new Document("""
+			Prose
+
+			```javascript
+			function foo() { return 1; }
+			// comment
+			```
+			""");
+		final var model = TMModelManager.INSTANCE.connect(mdDoc);
+		model.setGrammar(mdGrammar);
+
+		// Create a partitioner WITHOUT forcing grammar and connect via helper
+		final TMPartitioner p = new TMPartitioner();
+		mdDoc.setDocumentPartitioner(TMPartitions.TM_PARTITIONING, p);
+		p.connect(mdDoc);
+
+		// Trigger activation
+		p.getPartition(0);
+		TestUtils.waitForModelReady(mdDoc, 5_000);
+
+		final String text = mdDoc.get();
+		final int fence = text.indexOf("```javascript\n");
+		assertThat(fence).isGreaterThanOrEqualTo(0);
+		final int contentStart = fence + "```javascript\n".length();
+		final int fenceClose = text.indexOf("```", contentStart);
+		assertThat(fenceClose).isGreaterThan(contentStart);
+
+		final ITMPartitionRegion[] parts = p.computePartitioning(contentStart, fenceClose - contentStart);
+		assertThat(parts).hasSize(1);
+		assertThat(parts[0].getType()).isEqualTo("tm4e:source.js");
+		assertThat(parts[0].getGrammarScope()).isEqualTo("source.js");
+
+		p.disconnect();
+	}
+
+	@Test
+	void markdownFencedJavaIsSinglePartition() throws Exception {
+		// the white space between ; and // in the java scoped block is an IToken of type `text.html`
+		// this test ensures that the partitioner still makes a single partition of the whole fenced block
+		final var mdDoc = new Document(
+				"""
+					```java
+					System.out.println("World!");      // single line comment
+					```
+					""");
+		final var model = TMModelManager.INSTANCE.connect(mdDoc);
+		model.setGrammar(mdGrammar);
+
+		// Create a partitioner WITHOUT forcing grammar and connect via helper
+		final TMPartitioner p = new TMPartitioner();
+		mdDoc.setDocumentPartitioner(TMPartitions.TM_PARTITIONING, p);
+		p.connect(mdDoc);
+
+		// Trigger activation
+		p.getPartition(0);
+		TestUtils.waitForModelReady(mdDoc, 5_000);
+
+		final String text = mdDoc.get();
+		final int fence = text.indexOf("```java\n");
+		assertThat(fence).isGreaterThanOrEqualTo(0);
+		final int contentStart = fence + "```java\n".length();
+		final int fenceClose = text.indexOf("```", contentStart);
+		assertThat(fenceClose).isGreaterThan(contentStart);
+
+		final ITMPartitionRegion[] parts = p.computePartitioning(contentStart, fenceClose - contentStart);
+		assertThat(parts).hasSize(1);
+		assertThat(parts[0].getType()).isEqualTo("tm4e:source.java");
+		assertThat(parts[0].getGrammarScope()).isEqualTo("source.java");
+
+		p.disconnect();
+	}
+
+	@Test
+	void legalContentTypesIncludeEmbedded() throws Exception {
+		final var legal = partitioner.getLegalContentTypes();
+		assertThat(legal).contains("tm4e:source.css");
+		assertThat(legal).contains("tm4e:source.js");
+		// base is the html scope
+		assertThat(legal).anyMatch(s -> s.startsWith("tm4e:text."));
+	}
+
+	@Test
+	void partitionBoundaries() throws Exception {
+		final String text = doc.get();
+		final int styleTagStart = text.indexOf("<style>");
+		final int styleContent = styleTagStart + "<style>\n".length();
+		final int styleClose = text.indexOf("</style>");
+
+		// At the opening tag: base
+		assertThat(partitioner.getContentType(styleTagStart + 1)).startsWith(TMPartitioner.scopeToPartitionType("text."));
+		final ITMPartitionRegion tmPartition = partitioner.getPartition(styleTagStart + 1);
+		// Full scope should carry a specific variant (e.g., text.html.basic) and must not equal the normalized base
+		assertThat(tmPartition.getType()).isEqualTo("tm4e:text.html");
+		assertThat(tmPartition.getGrammarScope()).isEqualTo("text.html");
+
+		// First character inside CSS content: css
+		assertThat(partitioner.getContentType(styleContent)).isEqualTo("tm4e:source.css");
+		final ITMPartitionRegion cssRegion = partitioner.getPartition(styleContent);
+		assertThat(cssRegion.getType()).isEqualTo("tm4e:source.css");
+		assertThat(cssRegion.getGrammarScope()).isEqualTo("source.css");
+
+		// Last character before closing tag: css
+		assertThat(partitioner.getContentType(styleClose - 1)).isEqualTo("tm4e:source.css");
+		// At the '<' of closing tag: base
+		assertThat(partitioner.getContentType(styleClose)).startsWith(TMPartitioner.scopeToPartitionType("text."));
+
+		final int scriptTagStart = text.indexOf("<script>");
+		final int scriptContent = scriptTagStart + "<script>\n".length();
+		final int scriptClose = text.indexOf("</script>");
+
+		// At the opening tag: base
+		assertThat(partitioner.getContentType(scriptTagStart + 1)).startsWith(TMPartitioner.scopeToPartitionType("text."));
+		final ITMPartitionRegion scriptTagPartition = partitioner.getPartition(scriptTagStart + 1);
+		assertThat(scriptTagPartition.getType()).isEqualTo("tm4e:text.html");
+		assertThat(scriptTagPartition.getGrammarScope()).isEqualTo("text.html");
+
+		// Inside JS content: js
+		assertThat(partitioner.getContentType(scriptContent)).isEqualTo("tm4e:source.js");
+		final ITMPartitionRegion jsRegion = partitioner.getPartition(scriptContent);
+		assertThat(jsRegion.getType()).isEqualTo("tm4e:source.js");
+		assertThat(jsRegion.getGrammarScope()).isEqualTo("source.js");
+
+		// Last character before closing tag: js
+		assertThat(partitioner.getContentType(scriptClose - 1)).isEqualTo("tm4e:source.js");
+		// At the '<' of closing tag: base
+		assertThat(partitioner.getContentType(scriptClose)).startsWith(TMPartitioner.scopeToPartitionType("text."));
+	}
+
+	@Test
+	void partitionsEmbeddedLanguages() throws Exception {
+		// base HTML
+		final int htmlIdx = doc.get().indexOf("<html>") + 1;
+		final String baseType = partitioner.getContentType(htmlIdx);
+		assertThat(baseType).startsWith(TMPartitioner.scopeToPartitionType("text."));
+
+		// CSS inside <style>
+		final int cssIdx = doc.get().indexOf("color");
+		final String cssType = partitioner.getContentType(cssIdx);
+		assertThat(cssType).isEqualTo("tm4e:source.css");
+
+		// JS inside <script>
+		final int jsIdx = doc.get().indexOf("function x");
+		final String jsType = partitioner.getContentType(jsIdx);
+		assertThat(jsType).isEqualTo("tm4e:source.js");
+	}
+
+	@Test
+	void prefersExistingModelGrammar() throws Exception {
+		// Prepare a fresh document and set a grammar directly on the shared model
+		final var jsDoc = new Document("let a = 1;\n");
+		final var model = TMModelManager.INSTANCE.connect(jsDoc);
+		model.setGrammar(jsGrammar);
+
+		// Create a partitioner WITHOUT forcing grammar and connect via helper
+		final TMPartitioner p = new TMPartitioner();
+		jsDoc.setDocumentPartitioner(TMPartitions.TM_PARTITIONING, p);
+		p.connect(jsDoc);
+
+		// Trigger activation
+		p.getPartition(0);
+		TestUtils.waitForModelReady(jsDoc, 5_000);
+
+		// Partitioner's grammar should be the one already set on the model
+		assertThat(p.getGrammar()).isEqualTo(jsGrammar);
+		// And base partition type should reflect the TS scope
+		final String expectedBase = TMPartitioner.scopeToPartitionType(jsGrammar.getScopeName());
+		assertThat(p.getLegalContentTypes()).contains(expectedBase);
+
+		final ITypedRegion[] parts = p.computePartitioning(0, jsDoc.getLength());
+		assertThat(parts).isNotEmpty();
+		assertThat(parts[0].getType()).isEqualTo(expectedBase);
+
+		p.disconnect();
+	}
+
+	@BeforeEach
+	void setup() {
+		final var syndir = "../org.eclipse.tm4e.language_pack/syntaxes/";
+		reg.addGrammar(IGrammarSource.fromFile(Paths.get(syndir + "java/java.tmLanguage.json")));
+		reg.addGrammar(IGrammarSource.fromFile(Paths.get(syndir + "xml/xml.tmLanguage.json")));
+
+		reg.addGrammar(IGrammarSource.fromFile(Paths.get(syndir + "css/css.tmLanguage.json")));
+		jsGrammar = reg.addGrammar(IGrammarSource.fromFile(Paths.get(syndir + "javascript/javascript.tmLanguage.json")));
+		reg.addGrammar(IGrammarSource.fromFile(Paths.get(syndir + "html/text.html.basic.tmLanguage.json")));
+		final IGrammar htmlGrammar = reg.addGrammar(IGrammarSource.fromFile(Paths.get(syndir + "html/html.tmLanguage.json")));
+
+		mdGrammar = reg.addGrammar(IGrammarSource.fromFile(Paths.get(syndir + "markdown/markdown.tmLanguage.json")));
+
+		final String html = """
+			<html>
+			<head>
+			<style>
+			body { color: red; }
+			</style>
+			</head>
+			<body>
+			<script>
+			function x() { return 1; }
+			</script>
+			</body>
+			</html>
+			""";
+		doc = new Document(html);
+
+		partitioner = new TMPartitioner();
+		partitioner.setGrammar(htmlGrammar);
+
+		// Install the partitioner on the document so document changes notify it (invokes pruneAndFillBase)
+		doc.setDocumentPartitioner(TMPartitions.TM_PARTITIONING, partitioner);
+		partitioner.connect(doc);
+
+		// Trigger lazy activation so the TM model is connected before waiting
+		partitioner.getPartition(0);
+
+		TestUtils.waitForModelReady(doc, 5_000);
+	}
+
+	@AfterEach
+	void tearDown() {
+		if (partitioner != null) {
+			partitioner.disconnect();
+		}
+	}
+
+}

--- a/org.eclipse.tm4e.ui.tests/src/main/java/org/eclipse/tm4e/ui/tests/internal/text/TMPartitioningDocumentSetupParticipantTest.java
+++ b/org.eclipse.tm4e.ui.tests/src/main/java/org/eclipse/tm4e/ui/tests/internal/text/TMPartitioningDocumentSetupParticipantTest.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Vegard IT GmbH and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Sebastian Thomschke (Vegard IT) - initial implementation
+ *******************************************************************************/
+package org.eclipse.tm4e.ui.tests.internal.text;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.FileOutputStream;
+
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IDocumentExtension3;
+import org.eclipse.jface.text.ITypedRegion;
+import org.eclipse.tm4e.ui.internal.text.TMPartitioner;
+import org.eclipse.tm4e.ui.internal.utils.UI;
+import org.eclipse.tm4e.ui.tests.support.TestUtils;
+import org.eclipse.tm4e.ui.text.TMPartitions;
+import org.eclipse.ui.IEditorDescriptor;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.ide.IDE;
+import org.eclipse.ui.texteditor.ITextEditor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that TMDocumentSetupParticipant auto-installs the TM partitioner for documents with a resolvable grammar.
+ */
+class TMPartitioningDocumentSetupParticipantTest {
+
+	private IEditorDescriptor genericEditorDescr;
+	private IEditorPart editor;
+
+	@BeforeEach
+	void setup() throws Exception {
+		genericEditorDescr = TestUtils.assertHasGenericEditor();
+		TestUtils.assertNoTM4EThreadsRunning();
+	}
+
+	@AfterEach
+	void tearDown() throws Exception {
+		TestUtils.closeEditor(editor);
+		editor = null;
+		TestUtils.assertNoTM4EThreadsRunning();
+	}
+
+	@Test
+	void participantInstallsPartitioner() throws Exception {
+		// Use a temporary file outside workspace; participants should also engage via file store buffers
+		final File f = TestUtils.createTempFile(".ts");
+		try (var out = new FileOutputStream(f)) {
+			out.write("let a = 1;".getBytes());
+		}
+
+		editor = IDE.openEditor(UI.getActivePage(), f.toURI(), genericEditorDescr.getId(), true);
+
+		final var textEditor = (ITextEditor) editor;
+		final IDocument doc = textEditor.getDocumentProvider().getDocument(editor.getEditorInput());
+		assertThat(doc).isInstanceOf(IDocumentExtension3.class);
+
+		final var ext3 = (IDocumentExtension3) doc;
+		TestUtils.waitForAndAssertCondition(3_000, () -> ext3.getDocumentPartitioner(TMPartitions.TM_PARTITIONING) != null);
+
+		final var part = ext3.getDocumentPartitioner(TMPartitions.TM_PARTITIONING);
+		assertThat(part).as("TM partitioner is installed").isNotNull();
+
+		// Ensure the TM model has completed at least one tokenization pass before asserting
+		TestUtils.waitForModelReady(doc, 5_000);
+
+		final ITypedRegion r = part.getPartition(0);
+		assertThat(r.getType()).isEqualTo(TMPartitioner.scopeToPartitionType("source.ts"));
+	}
+}

--- a/org.eclipse.tm4e.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.tm4e.ui/META-INF/MANIFEST.MF
@@ -23,6 +23,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.eclipse.tm4e.ui,
  org.eclipse.tm4e.ui.internal.model;x-friends:="org.eclipse.tm4e.languageconfiguration,org.eclipse.tm4e.ui.tests",
  org.eclipse.tm4e.ui.internal.preferences;x-friends:="org.eclipse.tm4e.languageconfiguration",
+ org.eclipse.tm4e.ui.internal.text;x-friends:="org.eclipse.tm4e.ui.tests",
  org.eclipse.tm4e.ui.internal.themes;x-friends:="org.eclipse.tm4e.ui.tests",
  org.eclipse.tm4e.ui.internal.utils;x-friends:="org.eclipse.tm4e.ui.tests,org.eclipse.tm4e.languageconfiguration,org.eclipse.tm4e.languageconfiguration.tests",
  org.eclipse.tm4e.ui.internal.widgets;x-friends:="org.eclipse.tm4e.languageconfiguration",

--- a/org.eclipse.tm4e.ui/plugin.xml
+++ b/org.eclipse.tm4e.ui/plugin.xml
@@ -127,6 +127,13 @@
              contentType="org.eclipse.core.runtime.text" />
    </extension>
 
+   <!-- Auto-install TM4E partitioner (secondary partitioning) for text documents when a grammar exists -->
+   <extension point="org.eclipse.core.filebuffers.documentSetup">
+      <participant
+            class="org.eclipse.tm4e.ui.internal.text.TMPartitioningDocumentSetupParticipant"
+            contentTypeId="org.eclipse.core.runtime.text" />
+   </extension>
+
    <extension id="textmarker" point="org.eclipse.core.resources.markers">
       <super type="org.eclipse.core.resources.textmarker"/>
    </extension>

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/model/DocumentHelper.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/model/DocumentHelper.java
@@ -24,16 +24,15 @@ import org.eclipse.tm4e.core.internal.utils.StringUtils;
  */
 public final class DocumentHelper {
 
-	enum DocumentEventType {
+	public enum DocumentEventType {
 		INSERT,
 		REPLACE,
 		REMOVE
 	}
 
-	static DocumentEventType getEventType(final DocumentEvent event) {
-		if (StringUtils.isNullOrEmpty(event.getText())) {
+	public static DocumentEventType getEventType(final DocumentEvent event) {
+		if (StringUtils.isNullOrEmpty(event.getText()))
 			return DocumentEventType.REMOVE;
-		}
 		return event.getLength() == 0
 				? DocumentEventType.INSERT
 				: DocumentEventType.REPLACE;
@@ -50,13 +49,12 @@ public final class DocumentHelper {
 		return event.getDocument().getLineOfOffset(event.getOffset());
 	}
 
-	static int getEndLineIndexOfAddedText(final DocumentEvent event) throws BadLocationException {
+	public static int getEndLineIndexOfAddedText(final DocumentEvent event) throws BadLocationException {
 		final var doc = event.getDocument();
 		final var offsetAfterAddedText = event.getOffset() + event.getText().length();
 		final var isAppendToDocumentEnd = offsetAfterAddedText == doc.getLength();
-		if (isAppendToDocumentEnd) {
+		if (isAppendToDocumentEnd)
 			return doc.getNumberOfLines() - 1;
-		}
 		return doc.getLineOfOffset(offsetAfterAddedText);
 	}
 

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/text/TMPartitioner.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/text/TMPartitioner.java
@@ -1,0 +1,926 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Vegard IT GmbH and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Sebastian Thomschke (Vegard IT) - initial implementation
+ *******************************************************************************/
+package org.eclipse.tm4e.ui.internal.text;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.DocumentEvent;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.tm4e.core.grammar.IGrammar;
+import org.eclipse.tm4e.core.model.ITMModel.BackgroundTokenizationState;
+import org.eclipse.tm4e.core.model.ModelTokensChangedEvent;
+import org.eclipse.tm4e.core.model.Range;
+import org.eclipse.tm4e.core.model.TMToken;
+import org.eclipse.tm4e.registry.internal.TMScope;
+import org.eclipse.tm4e.ui.TMUIPlugin;
+import org.eclipse.tm4e.ui.internal.model.TMDocumentModel;
+import org.eclipse.tm4e.ui.internal.model.TMModelManager;
+import org.eclipse.tm4e.ui.internal.utils.GrammarUtils;
+import org.eclipse.tm4e.ui.text.ITMPartitionRegion;
+import org.eclipse.tm4e.ui.text.ITMPartitioner;
+import org.eclipse.tm4e.ui.text.TMPartitions;
+
+public final class TMPartitioner implements ITMPartitioner {
+
+	record TMPartitionRegion(int offset, int length, String type, String grammarScope)
+			implements ITMPartitionRegion {
+
+		private static String getGrammarScope(final String type, final @Nullable IGrammar grammar) {
+			if (grammar != null) {
+				final var grammarScope = normalizeBaseScope(grammar.getScopeName());
+				if (grammarScope != null)
+					return grammarScope;
+			}
+			return scopeFromPartitionType(type);
+		}
+
+		public TMPartitionRegion(final int offset, final int length, final TMPartitionRegion region) {
+			this(offset, length, region.type, region.grammarScope);
+		}
+
+		public TMPartitionRegion(final int offset, final int length, final String type, final @Nullable IGrammar grammar) {
+			this(offset, length, type, getGrammarScope(type, grammar));
+		}
+
+		@Override
+		public String getType() {
+			return type;
+		}
+
+		@Override
+		public int getLength() {
+			return length;
+		}
+
+		@Override
+		public int getOffset() {
+			return offset;
+		}
+
+		@Override
+		public String getGrammarScope() {
+			return grammarScope;
+		}
+	}
+
+	private static final String TEXT_UNKNOWN = "text.unknown";
+
+	private static String ensureGrammarScope(final String type, final @Nullable String candidate, final @Nullable String baseScope) {
+		if (candidate != null) {
+			final String normalized = normalizeVariantScope(candidate);
+			if (normalized != null)
+				return normalized;
+		}
+		if (TMPartitions.BASE_PARTITION_TYPE.equals(type)) {
+			final String normalizedBase = normalizeVariantScope(baseScope);
+			return normalizedBase != null ? normalizedBase : TEXT_UNKNOWN;
+		}
+		return scopeFromPartitionType(type);
+	}
+
+	private static @Nullable String normalizeBaseScope(@Nullable String scope) {
+		if (scope == null)
+			return null;
+		// Strip any contributor suffix (e.g., "@org.eclipse.tm4e.language_pack") while preserving variant details
+		scope = TMScope.toUnqualified(scope);
+		if (scope.startsWith("source.")) {
+			final int next = scope.indexOf('.', "source.".length());
+			return next > 0 ? scope.substring(0, next) : scope;
+		}
+		if (scope.startsWith("text.")) {
+			final int next = scope.indexOf('.', "text.".length());
+			return next > 0 ? scope.substring(0, next) : scope;
+		}
+		return scope;
+	}
+
+	private static @Nullable String normalizeVariantScope(final @Nullable String scope) {
+		if (scope == null)
+			return null;
+		// Strip any contributor suffix (e.g., "@org.eclipse.tm4e.language_pack") while preserving variant details
+		return TMScope.toUnqualified(scope);
+	}
+
+	private static String scopeFromPartitionType(final @Nullable String partitionType) {
+		if (partitionType != null && partitionType.startsWith(TMPartitions.PARTITION_TYPE_PREFIX)
+				&& !TMPartitions.BASE_PARTITION_TYPE.equals(partitionType))
+			return partitionType.substring(TMPartitions.PARTITION_TYPE_PREFIX.length());
+		return TEXT_UNKNOWN;
+	}
+
+	/**
+	 * Builds a partition type name for a TextMate language scope (e.g. source.js).
+	 * If the scope is qualified (e.g. "source.ts@com.example.bundle"), the contributor suffix is stripped.
+	 */
+	public static String scopeToPartitionType(final String scope) {
+		return TMPartitions.PARTITION_TYPE_PREFIX + normalizeBaseScope(scope);
+	}
+
+	/**
+	 * Partition type used for the document's base language when no embedded scope applies.
+	 * Initialized to {@code tm4e:base} and switched to {@code tm4e:<root-scope>} once a grammar is known.
+	 */
+	private volatile String basePartitionType = TMPartitions.BASE_PARTITION_TYPE;
+
+	/**
+	 * Partition index keyed by region start offset. Rules:
+	 * <li>Keys grow from left to right; regions do not overlap.
+	 * <li>Offsets/lengths use document offsets.
+	 * <li>Between indexed regions there can be gaps; these are treated as base type.
+	 */
+	private final TreeMap<Integer, TMPartitionRegion> partitions = new TreeMap<>();
+
+	/**
+	 * Discovered partition types for this document. Semantics:
+	 * <li>Always contains {@code basePartitionType} after connect/init.
+	 * <li>More types are added when we see embedded languages; cleared on disconnect/init.
+	 */
+	private final Set<String> legalTypes = new HashSet<>();
+
+	/**
+	 * Read/write lock that protects the mutable partition state:
+	 * <li>{@link #partitions}: read with the read lock, write with the write lock
+	 * <li>{@link #legalTypes}: read with the read lock, write with the write lock
+	 * <li>{@link #basePartitionType}: writes happen under the write lock together with the above structures to keep them consistent;
+	 * reads may occur without a lock because the field is {@code volatile}
+	 */
+	private final ReadWriteLock partitionsLock = new ReentrantReadWriteLock();
+
+	private final ModelTokensChangedEvent.Listener modelListener = this::onTokensChanged;
+
+	private volatile boolean activated;
+	private final Object activationLock = new Object();
+
+	private volatile @Nullable IDocument document;
+	private volatile @Nullable IGrammar grammar;
+	private volatile @Nullable TMDocumentModel tmModel;
+
+	/**
+	 * Merge segments that are next to each other and have the same type into one region.
+	 * <p>
+	 * Assumptions:
+	 * <li>The input list is sorted by {@code offset} and segments do not overlap.
+	 * <li>Segments use document offsets.
+	 */
+	private List<TMPartitionRegion> coalesce(final List<TMPartitionRegion> segs) {
+		if (segs.isEmpty())
+			return Collections.emptyList();
+
+		final var result = new ArrayList<TMPartitionRegion>(segs.size());
+		TMPartitionRegion prev = segs.get(0);
+		for (int i = 1; i < segs.size(); i++) {
+			final TMPartitionRegion cur = segs.get(i);
+			if (prev.getType().equals(cur.getType()) //
+					&& prev.getOffset() + prev.getLength() == cur.getOffset()) {
+				prev = new TMPartitionRegion(prev.getOffset(), prev.getLength() + cur.getLength(), prev.getType(), prev.getGrammarScope());
+			} else {
+				result.add(prev);
+				prev = cur;
+			}
+
+		}
+		result.add(prev);
+		return result;
+	}
+
+	/**
+	 * Utility: true when [start,end) is a non-empty span.
+	 */
+	private static boolean spans(final int start, final int end) {
+		return end > start;
+	}
+
+	/**
+	 * Utility: add a segment if it spans content and ensure its grammar scope is consistent.
+	 */
+	private static void addSeg(final List<TMPartitionRegion> out, final int start, final int end, final String type,
+			final @Nullable String scope, final @Nullable String baseScope) {
+		if (spans(start, end)) {
+			out.add(new TMPartitionRegion(start, end - start, type, ensureGrammarScope(type, scope, baseScope)));
+		}
+	}
+
+	/**
+	 * Compute the partitioning for the range {@code [offset, offset+length)}.
+	 * <p>
+	 * Strategy:
+	 * <ol>
+	 * <li>Clamp the requested range to the document boundaries.
+	 * <li>If no partitions are known, return one base segment covering the range.
+	 * <li>Iterate the stored partitions that overlap the range and:
+	 * <ul>
+	 * <li>Emit a base segment for any gap before the first/next partition.</li>
+	 * <li>Emit the overlapping slice of the partition.</li>
+	 * </ul>
+	 * <li>Emit a trailing base segment for any remaining gap until {@code end}.</li>
+	 * </ol>
+	 * Result: returned regions always cover the requested range contiguously, using base type for gaps.
+	 */
+	@Override
+	public ITMPartitionRegion[] computePartitioning(final int offset, final int length) {
+		ensureActivated();
+
+		partitionsLock.readLock().lock();
+		try {
+			final var doc = document;
+			if (doc == null)
+				return new ITMPartitionRegion[] { new TMPartitionRegion(0, 0, basePartitionType, (IGrammar) null) };
+			final var grammar = this.grammar;
+
+			// Fast path for empty ranges to keep intent obvious
+			if (length <= 0) {
+				final int start = Math.clamp(offset, 0, doc.getLength());
+				return new ITMPartitionRegion[] { new TMPartitionRegion(start, 0, basePartitionType, grammar) };
+			}
+
+			final int docLen = doc.getLength();
+			final int start = Math.clamp(offset, 0, docLen);
+			final int end = Math.clamp(offset + length, start, docLen);
+
+			if (partitions.isEmpty())
+				// no known partitions -> everything is base
+				return new ITMPartitionRegion[] { new TMPartitionRegion(start, Math.max(0, end - start), basePartitionType, grammar) };
+
+			final var list = new ArrayList<TMPartitionRegion>();
+
+			int cursor = start;
+			// Handle partition that starts before 'start' but overlaps it
+			final Map.Entry<Integer, TMPartitionRegion> floor = partitions.floorEntry(start);
+			if (floor != null) {
+				final TMPartitionRegion r = floor.getValue();
+				final int rStart = r.getOffset();
+				final int rEnd = rStart + r.getLength();
+				if (rStart < start && rEnd > start) {
+					final int to = Math.min(end, rEnd);
+					if (to > cursor) {
+						list.add(new TMPartitionRegion(cursor, to - cursor, r));
+						cursor = to;
+					}
+				}
+			}
+
+			// Walk only entries that can overlap [start, end)
+			for (final var e : partitions.subMap(start, true, Math.max(start, end - 1), true).entrySet()) {
+				if (cursor >= end)
+					break;
+				final int rStart = e.getKey();
+				final TMPartitionRegion r = e.getValue();
+				final int rEnd = rStart + r.getLength();
+
+				if (rStart > cursor) {
+					final int gapEnd = Math.min(end, rStart);
+					if (gapEnd > cursor) {
+						list.add(new TMPartitionRegion(cursor, gapEnd - cursor, basePartitionType, grammar));
+						cursor = gapEnd;
+					}
+				}
+
+				if (rEnd > cursor) {
+					final int to = Math.min(end, rEnd);
+					list.add(new TMPartitionRegion(cursor, to - cursor, r));
+					cursor = to;
+				}
+			}
+
+			// fill trailing base gap
+			if (cursor < end) {
+				list.add(new TMPartitionRegion(cursor, end - cursor, basePartitionType, grammar));
+			}
+
+			if (list.isEmpty())
+				return new ITMPartitionRegion[] { new TMPartitionRegion(start, Math.max(0, end - start), basePartitionType, grammar) };
+			return list.toArray(ITMPartitionRegion[]::new);
+		} finally {
+			partitionsLock.readLock().unlock();
+		}
+	}
+
+	@Override
+	public void connect(final IDocument doc) {
+		document = doc;
+		activated = false;
+
+		// start with no indexed partitions; callers get base type until activation
+		partitionsLock.writeLock().lock();
+		try {
+			partitions.clear();
+			legalTypes.clear();
+			legalTypes.add(basePartitionType);
+		} finally {
+			partitionsLock.writeLock().unlock();
+		}
+	}
+
+	@Override
+	public void disconnect() {
+		final var model = tmModel;
+		if (model != null) {
+			model.removeModelTokensChangedListener(modelListener);
+		}
+		tmModel = null;
+		document = null;
+		activated = false;
+		grammar = null;
+
+		partitionsLock.writeLock().lock();
+		try {
+			partitions.clear();
+			legalTypes.clear();
+			basePartitionType = TMPartitions.BASE_PARTITION_TYPE;
+		} finally {
+			partitionsLock.writeLock().unlock();
+		}
+	}
+
+	@Override
+	public void documentAboutToBeChanged(final DocumentEvent event) {
+		// no-op; we react to TM model events to rebuild partitions
+	}
+
+	@Override
+	public boolean documentChanged(final DocumentEvent event) {
+		// if not activated yet, do nothing (base will be provided on demand)
+		if (!activated || document == null)
+			return false;
+
+		// as a simple strategy, trim partitions from the change offset and mark as base until tokenization catches up
+		final int changeStart = Math.max(0, event.getOffset());
+		final int replacedLen = Math.max(0, event.getLength()); // length in old doc
+		final int addedLen = Math.max(0, event.getText().length());
+		final int oldEnd = changeStart + replacedLen; // coordinates in old partitions map
+		final int newEnd = changeStart + addedLen;   // coordinates in new document
+
+		// if no effective change, signal no partition updates
+		if (replacedLen == 0 && addedLen == 0)
+			return false;
+
+		return pruneAndFillBase(changeStart, oldEnd, newEnd);
+	}
+
+	/**
+	 * Ensure the partitioner is initialized and listening to the TM model.
+	 * Does nothing if already activated or no document is connected.
+	 */
+	private void ensureActivated() {
+		if (activated || document == null)
+			return;
+
+		synchronized (activationLock) {
+			if (activated || document == null)
+				return;
+			initializeModelAndBase();
+			rebuildAll();
+			activated = true;
+		}
+	}
+
+	@Override
+	public String getContentType(final int offset) {
+		return getPartition(offset).getType();
+	}
+
+	/**
+	 * Testing-only
+	 */
+	public @Nullable IGrammar getGrammar() {
+		return grammar;
+	}
+
+	@Override
+	public String[] getLegalContentTypes() {
+		ensureActivated();
+
+		partitionsLock.readLock().lock();
+		try {
+			return legalTypes.toArray(String[]::new);
+		} finally {
+			partitionsLock.readLock().unlock();
+		}
+	}
+
+	@Override
+	public ITMPartitionRegion getPartition(final int offset) {
+		ensureActivated();
+
+		partitionsLock.readLock().lock();
+		try {
+			final var doc = document;
+			if (doc == null)
+				return new TMPartitionRegion(0, 0, basePartitionType, grammar);
+			final int docLen = doc.getLength();
+			if (docLen == 0)
+				return new TMPartitionRegion(0, 0, basePartitionType, grammar);
+
+			if (partitions.isEmpty())
+				return new TMPartitionRegion(0, docLen, basePartitionType, grammar);
+
+			// clamp offset to [0, docLen-1] to handle EOF and negatives
+			final int clamped = Math.clamp(offset, 0, docLen - 1);
+
+			final Map.Entry<Integer, TMPartitionRegion> floor = partitions.floorEntry(clamped);
+			if (floor != null) {
+				final TMPartitionRegion region = floor.getValue();
+				final int regionEnd = region.getOffset() + region.getLength();
+				if (clamped >= region.getOffset() && clamped < regionEnd)
+					return region;
+			}
+
+			// no covering partition found: we are in a base gap.
+			// build a base region spanning from the end of the previous region (or 0) to the next region start (or doc end)
+			final int baseStart = floor != null ? Math.max(0, floor.getValue().getOffset() + floor.getValue().getLength()) : 0;
+			final Map.Entry<Integer, TMPartitionRegion> next = partitions.ceilingEntry(clamped);
+			final int baseEnd = next != null ? next.getKey() : docLen;
+			return new TMPartitionRegion(baseStart, Math.max(0, baseEnd - baseStart), basePartitionType, grammar);
+		} finally {
+			partitionsLock.readLock().unlock();
+		}
+	}
+
+	private void initializeModelAndBase() {
+		final var doc = Objects.requireNonNull(document);
+		final TMDocumentModel model = TMModelManager.INSTANCE.connect(doc);
+		tmModel = model;
+
+		// Prefer an existing model grammar to stay consistent with other clients (e.g., presenter)
+		final IGrammar modelGrammar = model.getGrammar();
+		if (modelGrammar != null) {
+			grammar = modelGrammar;
+		} else if (grammar == null) {
+			// resolve grammar if not forced
+			grammar = GrammarUtils.findGrammar(doc);
+		}
+
+		final var grammar = this.grammar;
+		if (grammar != null) {
+			model.setGrammar(grammar);
+			partitionsLock.writeLock().lock();
+			try {
+				basePartitionType = scopeToPartitionType(grammar.getScopeName());
+				legalTypes.clear();
+				legalTypes.add(basePartitionType);
+			} finally {
+				partitionsLock.writeLock().unlock();
+			}
+		} else {
+			partitionsLock.writeLock().lock();
+			try {
+				basePartitionType = TMPartitions.BASE_PARTITION_TYPE;
+				legalTypes.clear();
+				legalTypes.add(basePartitionType);
+			} finally {
+				partitionsLock.writeLock().unlock();
+			}
+		}
+
+		model.addModelTokensChangedListener(modelListener);
+	}
+
+	/**
+	 * Add {@code newSegs} into the current partition map.
+	 * <p>
+	 * Strategy:
+	 * <ol>
+	 * <li>Adjust the partition that crosses the left boundary.
+	 * <li>Remove all partitions that start inside [startOffset, endOffset).
+	 * <li>Adjust the partition that crosses the right boundary.
+	 * <li>Insert {@code newSegs}; if a new segment touches a neighbour with the same type, merge them.
+	 * </ol>
+	 * Assumptions:
+	 * <ol>
+	 * <li>{@code newSegs} are sorted by offset and do not overlap.
+	 * <li>Offsets use document positions and lie within [startOffset, endOffset].
+	 * </ol>
+	 */
+	private void integratePartitions(final int startOffset, final int endOffset, final List<TMPartitionRegion> newSegs) {
+		// capture right-crossing region BEFORE mutating the map so we can rebuild its right remainder later
+		TMPartitionRegion rightCrossing = null;
+		int rightCrossingEnd = -1;
+		final Map.Entry<Integer, TMPartitionRegion> rightCand = partitions.floorEntry(endOffset);
+		if (rightCand != null) {
+			final TMPartitionRegion region = rightCand.getValue();
+			final int regionEnd = region.getOffset() + region.getLength();
+			if (region.getOffset() < endOffset && regionEnd > endOffset) {
+				rightCrossing = region;
+				rightCrossingEnd = regionEnd;
+			}
+		}
+
+		// prepare left remainder if any
+		final Map.Entry<Integer, TMPartitionRegion> left = partitions.floorEntry(startOffset);
+		if (left != null) {
+			final TMPartitionRegion region = left.getValue();
+			final int regionEnd = region.getOffset() + region.getLength();
+			if (regionEnd > startOffset) {
+				// overlap -> replace with left remainder
+				partitions.remove(left.getKey());
+				if (region.getOffset() < startOffset) {
+					partitions.put(region.getOffset(), new TMPartitionRegion(region.getOffset(), startOffset - region.getOffset(), region));
+				}
+			}
+		}
+
+		// drop all entries starting in [startOffset, endOffset) using a bounded view
+		final var bounded = partitions.subMap(startOffset, true, endOffset, false);
+		if (!bounded.isEmpty()) {
+			bounded.clear();
+		}
+
+		// recreate right remainder if a region originally crossed endOffset
+		if (rightCrossing != null) {
+			partitions.put(endOffset, new TMPartitionRegion(endOffset, rightCrossingEnd - endOffset, rightCrossing));
+		}
+
+		// insert new segments; merge with neighbours of the same type when they touch (both sides)
+		for (final TMPartitionRegion seg : newSegs) {
+			int newStart = seg.getOffset();
+			int newLen = seg.getLength();
+			final String type = seg.getType();
+			final String grammarScope = seg.getGrammarScope();
+
+			// merge with previous neighbour if it touches and has same type
+			final Map.Entry<Integer, TMPartitionRegion> prev = partitions.floorEntry(newStart);
+			if (prev != null) {
+				final TMPartitionRegion pr = prev.getValue();
+				final int pEnd = pr.getOffset() + pr.getLength();
+				if (pEnd == newStart && pr.getType().equals(type)) {
+					newStart = pr.getOffset();
+					newLen += pr.getLength();
+					partitions.remove(prev.getKey());
+				}
+			}
+
+			// merge repeatedly with following neighbours while contiguous and of same type
+			while (true) {
+				final int expectedNextStart = newStart + newLen;
+				final TMPartitionRegion nr = partitions.get(expectedNextStart);
+				if (nr != null && nr.getType().equals(type)) {
+					newLen += nr.getLength();
+					partitions.remove(expectedNextStart);
+					continue;
+				}
+				break;
+			}
+
+			partitions.put(newStart, new TMPartitionRegion(newStart, newLen, type, grammarScope));
+		}
+	}
+
+	/**
+	 * Reacts to token changes from the TM model.
+	 * <p>
+	 * Strategy:
+	 * <li>Merges overlapping or adjacent line-based ranges from {@code event.ranges} to minimize recomputation.</li>
+	 * <li>For each merged line range, converts it to document offsets and calls {@link #recomputeRange(int, int)}.</li>
+	 * Errors resolving line offsets are logged.
+	 */
+	private void onTokensChanged(final ModelTokensChangedEvent event) {
+		final var doc = document;
+		if (doc == null)
+			return;
+
+		try {
+			// Merge overlapping or adjacent line ranges to reduce recomputation and lock churn
+			if (event.ranges.isEmpty())
+				return;
+
+			final var ranges = new ArrayList<int[]>(event.ranges.size());
+			for (final Range r : event.ranges) {
+				final int s = Math.max(0, r.fromLineNumber - 1);
+				final int e = Math.max(s, r.toLineNumber - 1);
+				ranges.add(new int[] { s, e });
+			}
+
+			ranges.sort((a, b) -> Integer.compare(a[0], b[0]));
+
+			int curS = ranges.get(0)[0];
+			int curE = ranges.get(0)[1];
+			for (int i = 1; i < ranges.size(); i++) {
+				final int s = ranges.get(i)[0];
+				final int e = ranges.get(i)[1];
+				if (s <= curE + 1) { // overlap or adjacent
+					if (e > curE) {
+						curE = e;
+					}
+					continue;
+				}
+				// flush current merged range
+				final int startOffset = doc.getLineOffset(curS);
+				final int endOffset = doc.getLineOffset(curE) + doc.getLineLength(curE);
+				recomputeRange(startOffset, endOffset);
+
+				// start new merged range
+				curS = s;
+				curE = e;
+			}
+			// flush last merged range
+			final int startOffset = doc.getLineOffset(curS);
+			final int endOffset = doc.getLineOffset(curE) + doc.getLineLength(curE);
+			recomputeRange(startOffset, endOffset);
+		} catch (final BadLocationException ex) {
+			TMUIPlugin.logError(ex);
+		}
+	}
+
+	/**
+	 * Precisely reset only the changed span to base and maintain correctness for partitions to the right.
+	 * <p>
+	 * Why: when a user edits text, only the modified span becomes potentially invalid. We want to:
+	 * <li>discard stale embedded partitions within the modified range,</li>
+	 * <li>keep partitions to the left untouched,</li>
+	 * <li>preserve partitions to the right by shifting them by the edit delta so their offsets remain correct,</li>
+	 * <li>and bridge the changed span with a single base region until the tokenizer recomputes tokens.</li>
+	 * <p>
+	 * Steps:
+	 * <ol>
+	 * <li>Normalize inputs and compute {@code delta = newEndOffset - oldEndOffset}.</li>
+	 * <li>Capture any partition that crosses {@code oldEndOffset} so its right remainder can be restored at {@code newEndOffset}.</li>
+	 * <li>Collect all partitions starting at or after {@code oldEndOffset} to shift them by {@code delta} later.</li>
+	 * <li>Remove all partitions whose start lies within {@code [startOffset, oldEndOffset)}.</li>
+	 * <li>If a partition crosses {@code startOffset}, shrink it to end at {@code startOffset}.</li>
+	 * <li>Shift all collected right-side partitions by {@code delta} so they retain their logical position after the edit.</li>
+	 * <li>Recreate the captured right remainder at {@code newEndOffset} (keeping its original type and length).</li>
+	 * <li>Insert a single base partition covering {@code [startOffset, newEndOffset)}.</li>
+	 * </ol>
+	 * Assumptions:
+	 * <ol>
+	 * <li>{@code startOffset}, {@code oldEndOffset}, {@code newEndOffset} refer to document offsets; {@code oldEndOffset}
+	 * is measured on the pre-edit content, {@code newEndOffset} on the post-edit content.</li>
+	 * <li>Offsets are clamped internally to ensure {@code start <= oldEnd} and {@code start <= newEnd}.</li>
+	 * <li>Calling code provides consistent offsets derived from a single {@link DocumentEvent}.</li>
+	 * </ol>
+	 * Result: partitions to the left remain intact; the changed span is a base bridge; partitions to the right keep their
+	 * original types and relative order with updated offsets. Subsequent tokenization will refine the base span.
+	 *
+	 * @param startOffset start of changed span (old and new doc)
+	 * @param oldEndOffset end of replaced span in the old doc coordinates
+	 * @param newEndOffset end of inserted span in the new doc coordinates
+	 *
+	 * @return true if the partition map was modified; false otherwise
+	 */
+	private boolean pruneAndFillBase(final int startOffset, final int oldEndOffset, final int newEndOffset) {
+		partitionsLock.writeLock().lock();
+		try {
+			final var grammar = this.grammar;
+			boolean changed = false;
+			final int boundedStart = Math.clamp(startOffset, 0, oldEndOffset);
+			final int boundedOldEnd = Math.max(boundedStart, oldEndOffset);
+			final int boundedNewEnd = Math.max(boundedStart, newEndOffset);
+			final int delta = boundedNewEnd - boundedOldEnd;
+
+			if (partitions.isEmpty()) {
+				// Only add a base region when there is an actual span to bridge
+				if (boundedNewEnd > boundedStart) {
+					partitions.put(boundedStart,
+							new TMPartitionRegion(boundedStart, boundedNewEnd - boundedStart, basePartitionType, grammar));
+					return true;
+				}
+				return false;
+			}
+
+			// capture right-crossing region BEFORE mutating the map so we can rebuild its right remainder later
+			TMPartitionRegion rightCrossing = null;
+			int rightCrossingEnd = -1;
+			final Map.Entry<Integer, TMPartitionRegion> rightCand = partitions.floorEntry(boundedOldEnd);
+			if (rightCand != null) {
+				final TMPartitionRegion region = rightCand.getValue();
+				final int regionEnd = region.getOffset() + region.getLength();
+				if (region.getOffset() < boundedOldEnd && regionEnd > boundedOldEnd) {
+					rightCrossing = region;
+					rightCrossingEnd = regionEnd;
+				}
+			}
+
+			// remove entries starting within [boundedStart, boundedOldEnd) using a bounded view
+			final var toDrop = partitions.subMap(boundedStart, true, boundedOldEnd, false);
+			if (!toDrop.isEmpty()) {
+				toDrop.clear();
+				changed = true;
+			}
+
+			// adjust possible left partition that overlaps startOffset
+			final Map.Entry<Integer, TMPartitionRegion> left = partitions.floorEntry(boundedStart);
+			if (left != null) {
+				final TMPartitionRegion region = left.getValue();
+				final int regionEnd = region.getOffset() + region.getLength();
+				if (regionEnd > boundedStart) {
+					partitions.put(region.getOffset(),
+							new TMPartitionRegion(region.getOffset(), boundedStart - region.getOffset(), region));
+					changed = true;
+				}
+			}
+
+			// shift tail entries (>= oldEnd) by delta so they keep their position
+			if (delta != 0) {
+				final var tailView = partitions.tailMap(boundedOldEnd, true);
+				if (!tailView.isEmpty()) {
+					final var shifted = new TreeMap<Integer, TMPartitionRegion>();
+					for (final var e : tailView.entrySet()) {
+						final int oldKey = e.getKey();
+						final TMPartitionRegion region = e.getValue();
+						final int newStart = oldKey + delta;
+						shifted.put(newStart, new TMPartitionRegion(newStart, region.getLength(), region));
+					}
+					// remove all tail entries in one shot and insert shifted ones
+					tailView.clear();
+					partitions.putAll(shifted);
+					changed = true;
+				}
+			}
+
+			// recreate right remainder if a region originally crossed oldEnd
+			if (rightCrossing != null) {
+				partitions.put(boundedNewEnd, new TMPartitionRegion(boundedNewEnd, rightCrossingEnd - boundedOldEnd, rightCrossing));
+				changed = true;
+			}
+
+			// add a base region spanning [boundedStart, boundedNewEnd)
+			if (boundedNewEnd > boundedStart) {
+				partitions.put(boundedStart, new TMPartitionRegion(boundedStart, boundedNewEnd - boundedStart, basePartitionType, grammar));
+				changed = true;
+			}
+			return changed;
+		} finally {
+			partitionsLock.writeLock().unlock();
+		}
+	}
+
+	private void rebuildAll() {
+		final var model = tmModel;
+		final var doc = document;
+		// if tokenization is still in progress, keep base-only until events arrive
+		if (model == null || doc == null || model.getBackgroundTokenizationState() != BackgroundTokenizationState.COMPLETED)
+			return;
+
+		try {
+			recomputeRange(0, doc.getLength());
+		} catch (final BadLocationException ex) {
+			TMUIPlugin.logTrace(ex);
+		}
+	}
+
+	/**
+	 * Rebuild partitions for the text range [startOffset, endOffset) (end not included).
+	 * <p>
+	 * Strategy and invariants:
+	 * <li>Iterate the model line by line and normalize each token's grammar scope at most once per token.
+	 * <li>Prefer embedded scopes (e.g., {@code source.*}) over base scopes (e.g., {@code text.*}).
+	 * <li>Precompute whether a line contains any embedded token to avoid nested lookahead scans in the hot path
+	 * (indentation case: base token at column 0 followed by embedded content later on the same line).
+	 * <li>Build a minimal list of contiguous segments, then coalesce and integrate into the tree under a write lock.
+	 */
+	private void recomputeRange(final int startOffset, final int endOffset) throws BadLocationException {
+		final var model = tmModel;
+		final var doc = document;
+		// Nothing to recompute for an empty range
+		if (model == null || doc == null || endOffset <= startOffset)
+			return;
+
+		final var grammar = this.grammar;
+		final String baseScope = grammar != null ? normalizeVariantScope(grammar.getScopeName()) : null;
+		final String baseRoot = normalizeBaseScope(baseScope);
+		final String baseRootNN = baseRoot != null ? baseRoot : TEXT_UNKNOWN;
+
+		// Build new segments for the changed range
+		final var newSegs = new ArrayList<TMPartitionRegion>();
+
+		final int startLine = doc.getLineOfOffset(startOffset);
+		final int endLine = doc.getLineOfOffset(endOffset - 1);
+
+		String currentType = null;
+		String currentGrammarScopeStr = null;
+		int currentStart = startOffset;
+
+		for (int line = startLine; line <= endLine; line++) {
+			final int lineOffset = doc.getLineOffset(line);
+			final int lineEnd = lineOffset + doc.getLineLength(line);
+			final List<TMToken> tokens = model.getLineTokens(line);
+
+			if (tokens == null || tokens.isEmpty()) {
+				// No tokens for this line: extend current segment using base when not initialized yet
+				if (currentType == null) {
+					currentType = basePartitionType;
+					currentGrammarScopeStr = baseRootNN;
+					// extend segment to end of line
+					// currentStart remains unchanged
+				}
+			} else {
+				// Precompute embedded token boundaries on this line to reduce nested lookahead work.
+				// We keep both the first and the last embedded token start indices so we can
+				// treat transient base tokens between embedded tokens as part of the embedded run.
+				int firstEmbeddedStart = -1;
+				int lastEmbeddedStart = -1;
+				for (final TMToken t : tokens) {
+					final String prefNorm = t.grammarScope == null ? null : normalizeVariantScope(t.grammarScope);
+					if (prefNorm != null && !Objects.equals(normalizeBaseScope(prefNorm), baseRootNN)) {
+						if (firstEmbeddedStart < 0)
+							firstEmbeddedStart = t.startIndex;
+						lastEmbeddedStart = t.startIndex;
+					}
+				}
+
+				for (final TMToken tok : tokens) {
+					final String prefNorm = tok.grammarScope == null ? null : normalizeVariantScope(tok.grammarScope);
+					final boolean isBase = prefNorm == null || Objects.equals(normalizeBaseScope(prefNorm), baseRootNN);
+					final String root = isBase ? basePartitionType : scopeToPartitionType(prefNorm != null ? prefNorm : baseRootNN);
+
+					if (currentType == null) {
+						currentType = root;
+						final boolean isEmbedded = !isBase;
+						final int firstTokenStart = lineOffset + tok.startIndex;
+						currentStart = Math.max(currentStart, isEmbedded ? lineOffset : firstTokenStart);
+						currentGrammarScopeStr = isBase ? baseRootNN : prefNorm;
+						continue;
+					}
+
+					if (!currentType.equals(root)) {
+						// While inside an embedded run, ignore base tokens that appear
+						// either at the start of the line (indentation) when another embedded token exists later,
+						// or anywhere before the last embedded token on this line (transient gaps between embedded tokens).
+						if (!currentType.equals(basePartitionType) && basePartitionType.equals(root)) {
+							final boolean baseAtLineStartWithEmbedLater = tok.startIndex == 0 && firstEmbeddedStart > 0;
+							final boolean baseBeforeLastEmbedded = lastEmbeddedStart > 0 && tok.startIndex <= lastEmbeddedStart;
+							if (baseAtLineStartWithEmbedLater || baseBeforeLastEmbedded) {
+								// keep currentType and currentStart as-is
+								continue;
+							}
+						}
+						// Token type changed: finalize previous segment and start a new one
+						final int segEnd = lineOffset + tok.startIndex;
+						addSeg(newSegs, currentStart, segEnd, currentType, currentGrammarScopeStr, baseScope);
+						currentType = root;
+						currentStart = segEnd;
+						currentGrammarScopeStr = isBase ? baseRootNN : prefNorm;
+					}
+				}
+			}
+
+			// at end of line: make sure currentType is set so we can close the last segment
+			if (currentType == null) {
+				currentType = basePartitionType;
+				currentGrammarScopeStr = baseRootNN;
+			}
+
+			// if the next line has tokens we continue the current run; we flush at endLine
+			if (line == endLine) {
+				// close the last segment at endOffset limit
+				final int finalEnd = Math.min(lineEnd, endOffset);
+				addSeg(newSegs, currentStart, finalEnd, currentType, currentGrammarScopeStr, baseScope);
+			}
+		}
+
+		if (newSegs.isEmpty() && endOffset > startOffset) {
+			// fallback: at least one base segment covering the requested range
+			addSeg(newSegs, startOffset, endOffset, basePartitionType, baseScope, baseScope);
+		}
+
+		// merge new segments that are next to each other and have the same type
+		final List<TMPartitionRegion> merged = coalesce(newSegs);
+		// add them to the map: remove overlaps and keep the other parts
+		final Set<String> newTypes = new HashSet<>();
+		for (final TMPartitionRegion r : merged) {
+			newTypes.add(r.getType());
+		}
+		partitionsLock.writeLock().lock();
+		try {
+			legalTypes.addAll(newTypes);
+			integratePartitions(startOffset, endOffset, merged);
+		} finally {
+			partitionsLock.writeLock().unlock();
+		}
+	}
+
+	/**
+	 * Testing-only: forces the grammar for the current connection.
+	 * Production code should rely on automatic grammar resolution.
+	 * Cleared on disconnect; does not persist across connections.
+	 *
+	 * @noreference
+	 */
+	public void setGrammar(final @Nullable IGrammar newGrammar) {
+		grammar = newGrammar;
+		if (document != null) {
+			initializeModelAndBase();
+			rebuildAll();
+		}
+	}
+}

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/text/TMPartitioningDocumentSetupParticipant.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/internal/text/TMPartitioningDocumentSetupParticipant.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Vegard IT GmbH and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Sebastian Thomschke (Vegard IT) - initial implementation
+ *******************************************************************************/
+package org.eclipse.tm4e.ui.internal.text;
+
+import org.eclipse.core.filebuffers.IDocumentSetupParticipant;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IDocumentExtension3;
+import org.eclipse.tm4e.ui.TMUIPlugin;
+import org.eclipse.tm4e.ui.text.TMPartitions;
+
+/**
+ * Auto-installs {@link TMPartitioner} under the tm4e.partitioning ID when a TextMate grammar can be resolved for the document.
+ *
+ * The default (editor) partitioner is not replaced; this adds a secondary partitioning that consumers can opt-in to use.
+ */
+public final class TMPartitioningDocumentSetupParticipant implements IDocumentSetupParticipant {
+
+	@Override
+	public void setup(final IDocument doc) {
+		// avoid impacting non-ext3 documents
+		if (!(doc instanceof final IDocumentExtension3 ext3)) //
+			return;
+
+		try {
+			if (ext3.getDocumentPartitioner(TMPartitions.TM_PARTITIONING) != null)
+				return; // already installed
+
+			final var partitioner = new TMPartitioner();
+			ext3.setDocumentPartitioner(TMPartitions.TM_PARTITIONING, partitioner);
+			partitioner.connect(doc);
+		} catch (final Exception ex) {
+			TMUIPlugin.logTrace(ex);
+		}
+	}
+}

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/text/ITMPartitionRegion.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/text/ITMPartitionRegion.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Vegard IT GmbH and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Sebastian Thomschke (Vegard IT) - initial implementation
+ *******************************************************************************/
+package org.eclipse.tm4e.ui.text;
+
+import org.eclipse.jface.text.ITypedRegion;
+
+public interface ITMPartitionRegion extends ITypedRegion {
+
+	/**
+	 * Returns the effective grammar scope for this region (e.g., "source.css", "source.js", "text.html").
+	 * Never null; falls back to a best-effort value when the document grammar is not yet resolved.
+	 */
+	String getGrammarScope();
+}

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/text/ITMPartitioner.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/text/ITMPartitioner.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Vegard IT GmbH and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Sebastian Thomschke (Vegard IT) - initial implementation
+ *******************************************************************************/
+package org.eclipse.tm4e.ui.text;
+
+import org.eclipse.jface.text.IDocumentPartitioner;
+
+/**
+ * A coarse-grained partitioner that derives Eclipse document partitions from TM tokenization.
+ *
+ * Partitions are computed as contiguous regions grouped by their top-level TextMate language scope
+ * (e.g., base scope like text.html.basic, or embedded scopes like source.js, source.css).
+ */
+public interface ITMPartitioner extends IDocumentPartitioner {
+
+	@Override
+	ITMPartitionRegion[] computePartitioning(final int offset, final int length);
+
+	@Override
+	ITMPartitionRegion getPartition(final int offset);
+}

--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/text/TMPartitions.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/text/TMPartitions.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Vegard IT GmbH and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Sebastian Thomschke (Vegard IT) - initial implementation
+ *******************************************************************************/
+package org.eclipse.tm4e.ui.text;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.eclipse.core.runtime.content.IContentType;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IDocumentExtension3;
+import org.eclipse.jface.text.ITypedRegion;
+import org.eclipse.tm4e.registry.IGrammarDefinition;
+import org.eclipse.tm4e.registry.ITMScope;
+import org.eclipse.tm4e.registry.TMEclipseRegistryPlugin;
+
+/**
+ * Constants for the TM partitioning and partition types.
+ */
+public final class TMPartitions {
+
+	private static final IContentType[] NO_CONTENT_TYPES = new IContentType[0];
+
+	/** The identifier for TM partitioning to be used with e.g. {@link IDocumentExtension3#getDocumentPartitioner(String)} */
+	public static final String TM_PARTITIONING = "tm4e.partitioning";
+
+	public static final String PARTITION_TYPE_PREFIX = "tm4e:";
+
+	/** Fallback/base partition type for the document's main language scope. */
+	public static final String BASE_PARTITION_TYPE = PARTITION_TYPE_PREFIX + "base";
+
+	/**
+	 * @return true if the given document has a TM4E partitioner installed.
+	 */
+	public static boolean hasPartitioning(final @Nullable IDocument doc) {
+		return doc instanceof final IDocumentExtension3 ext3 //
+				&& ext3.getDocumentPartitioner(TMPartitions.TM_PARTITIONING) != null;
+	}
+
+	/**
+	 * @return the TM4E partition at the given offset or <code>null</code> when no TM partitioner is installed.
+	 */
+	public static @Nullable ITMPartitionRegion getPartition(final IDocument doc, final int offset) {
+		if (doc instanceof final IDocumentExtension3 ext3
+				&& ext3.getDocumentPartitioner(TMPartitions.TM_PARTITIONING) instanceof final ITMPartitioner tmPartitioner)
+			return tmPartitioner.getPartition(offset);
+		return null;
+	}
+
+	/**
+	 * Resolves content types associated with the TM4E partition at the given offset.
+	 * Returns an empty array when no mapping exists or no TM partitioner is installed.
+	 */
+	public static IContentType[] getContentTypesForOffset(final IDocument doc, final int offset) {
+		final ITypedRegion part = getPartition(doc, offset);
+		if (part == null)
+			return NO_CONTENT_TYPES;
+
+		if (!(part instanceof final ITMPartitionRegion tmPart))
+			return NO_CONTENT_TYPES;
+
+		final String scopeName = tmPart.getGrammarScope();
+		final var mgr = TMEclipseRegistryPlugin.getGrammarRegistryManager();
+		// Try direct lookup (works when scope was contributed unqualified)
+		final Collection<IContentType> cts = mgr.getContentTypesForScope(ITMScope.parse(scopeName));
+		if (cts != null && !cts.isEmpty())
+			return cts.toArray(IContentType[]::new);
+
+		// Fallback: match by unqualified scope name across all definitions and union their content types
+		final List<IContentType> result = new ArrayList<>();
+		for (final IGrammarDefinition def : mgr.getDefinitions()) {
+			final var defScope = def.getScope();
+			if (scopeName.equals(defScope.getName())) {
+				final Collection<IContentType> mapped = mgr.getContentTypesForScope(defScope);
+				if (mapped != null && !mapped.isEmpty()) {
+					result.addAll(mapped);
+				}
+			}
+		}
+		return result.isEmpty() ? NO_CONTENT_TYPES : result.toArray(IContentType[]::new);
+	}
+
+	private TMPartitions() {
+	}
+}


### PR DESCRIPTION
Fixes #238. Documents are partitioned by embedded language. Partitioning happens only on-demand if requested.

When the option `Show TextMate token info in hovers` is enabled partition info is now shown too now:
<img width="734" height="559" alt="image" src="https://github.com/user-attachments/assets/4294738f-3ad4-41a4-afd4-04475475f32f" />
