### PR TITLE
fix: lazy initialize ImageRegistry

### DIFF
--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/TMUIPlugin.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/TMUIPlugin.java
@@ -23,6 +23,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.jface.text.templates.TemplateContextType;
 import org.eclipse.jface.text.templates.persistence.TemplateStore;
 import org.eclipse.text.templates.ContextTypeRegistry;
@@ -170,8 +171,11 @@ public class TMUIPlugin extends AbstractUIPlugin {
 				}
 			});
 		}
+	}
 
-		TMImages.initalize(getImageRegistry());
+	@Override
+	protected void initializeImageRegistry(final ImageRegistry registry) {
+		TMImages.initalize(registry);
 	}
 
 	@Override


### PR DESCRIPTION
This change adjusts `TMUIPlugin.start()` to not initialize the `ImageRegistry`, avoiding start-up exceptions when `TMUIPlugin.start()` is not called from a UI thread.

Instead, the `ImageRegistry` is initialized lazily by overriding: `AbstractUIPlugin.initializeImageRegistry()`
    
Fixes: https://github.com/eclipse-tm4e/tm4e/issues/1010