### PR TITLE
build: Add org.eclipse.orbit.xml-apis-ext to category.xml

### DIFF
--- a/org.eclipse.tm4e.repository/category.xml
+++ b/org.eclipse.tm4e.repository/category.xml
@@ -12,6 +12,15 @@
    <bundle id="com.google.gson" version="0.0.0">
       <category name="Dependencies"/>
    </bundle>
+   <!--
+     This is a transitive dependency of org.apache.batik.css.
+     It provides package org.w3c.dom.svg version 1.1.0 and org.w3c.css.sac version 1.3.0.
+     Without this bundle in the update site, tm4e cannot be installed unless those packages are provided by some other update site.
+     The Eclipse Platform 4.41 no longer provides this bundle in its update site nor includes it in the installation.
+   -->
+   <bundle id="org.eclipse.orbit.xml-apis-ext" version="0.0.0">
+      <category name="Dependencies"/>
+   </bundle>
    <bundle id="org.apache.batik.constants" version="0.0.0">
       <category name="Dependencies"/>
    </bundle>

--- a/target-platforms/latest.target
+++ b/target-platforms/latest.target
@@ -24,17 +24,11 @@
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2025-12/"/>
       <unit id="assertj-core" version="0.0.0"/>
-      <unit id="assertj-core.source" version="0.0.0"/>
       <unit id="com.google.gson" version="0.0.0"/>
-      <unit id="com.google.gson.source" version="0.0.0"/>
       <unit id="org.apache.batik.css" version="0.0.0"/>
-      <unit id="org.apache.batik.css.source" version="0.0.0"/>
       <unit id="org.jcodings" version="0.0.0"/>
-      <unit id="org.jcodings.source" version="0.0.0"/>
       <unit id="org.joni" version="0.0.0"/>
-      <unit id="org.joni.source" version="0.0.0"/>
       <unit id="org.snakeyaml.engine" version="0.0.0"/>
-      <unit id="org.snakeyaml.engine.source" version="0.0.0"/>
       <unit id="org.junit" version="0.0.0"/>
 
       <!-- Pinning JUnit 5 for now -->

--- a/target-platforms/oldest.target
+++ b/target-platforms/oldest.target
@@ -24,17 +24,11 @@
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2025-12/"/>
       <unit id="assertj-core" version="0.0.0"/>
-      <unit id="assertj-core.source" version="0.0.0"/>
       <unit id="com.google.gson" version="0.0.0"/>
-      <unit id="com.google.gson.source" version="0.0.0"/>
       <unit id="org.apache.batik.css" version="0.0.0"/>
-      <unit id="org.apache.batik.css.source" version="0.0.0"/>
       <unit id="org.jcodings" version="0.0.0"/>
-      <unit id="org.jcodings.source" version="0.0.0"/>
       <unit id="org.joni" version="0.0.0"/>
-      <unit id="org.joni.source" version="0.0.0"/>
       <unit id="org.snakeyaml.engine" version="0.0.0"/>
-      <unit id="org.snakeyaml.engine.source" version="0.0.0"/>
       <unit id="org.junit" version="0.0.0"/>
 
       <!-- JUnit 6 not supported by Eclipse 2024-06 -> pinning to JUnit 5 -->

--- a/target-platforms/staging.target
+++ b/target-platforms/staging.target
@@ -8,9 +8,9 @@
       <unit id="org.eclipse.license.feature.group" version="2.0.2.v20181016-2210"/>
     </location>
 
-    <!-- 4.40 = Eclipse 2026-03 -->
+    <!-- 4.41 = Eclipse 2026-09 -->
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-      <repository location="https://download.eclipse.org/eclipse/updates/4.40-I-builds"/>
+      <repository location="https://download.eclipse.org/eclipse/updates/4.41-I-builds"/>
       <unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.ui.trace" version="0.0.0"/>
       <unit id="org.eclipse.ui.tests.harness" version="0.0.0"/>
@@ -24,17 +24,11 @@
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/latest"/>
       <unit id="assertj-core" version="0.0.0"/>
-      <unit id="assertj-core.source" version="0.0.0"/>
       <unit id="com.google.gson" version="0.0.0"/>
-      <unit id="com.google.gson.source" version="0.0.0"/>
       <unit id="org.apache.batik.css" version="0.0.0"/>
-      <unit id="org.apache.batik.css.source" version="0.0.0"/>
       <unit id="org.jcodings" version="0.0.0"/>
-      <unit id="org.jcodings.source" version="0.0.0"/>
       <unit id="org.joni" version="0.0.0"/>
-      <unit id="org.joni.source" version="0.0.0"/>
       <unit id="org.snakeyaml.engine" version="0.0.0"/>
-      <unit id="org.snakeyaml.engine.source" version="0.0.0"/>
       <unit id="org.junit" version="0.0.0"/>
 
       <!-- Pinning JUnit 5 for now -->


### PR DESCRIPTION
- Remove explicit *.source from *.target because includeSource="true" implies that.
- Update staging.target to work with latest 4.41 I-bulds.

https://github.com/eclipse-simrel/simrel.build/issues/1432

This ensures that the TM4E update site's dependencies are transitively more complex.